### PR TITLE
build: prevent accidental glob-resolve into option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ cd "$PACKAGE/Frameworks/Python.framework/Versions/Current"
 
 rm -rf include share
 cd lib
-rm -rf tdb* tk* Tk* libtk* *tcl*
+rm -rf -- tdb* tk* Tk* libtk* *tcl*
 cd python3.*
 rm -rf test ensurepip idlelib
 cd lib-dynload


### PR DESCRIPTION
Preventing `*tcl*` accidentally resolving in an option (leading `-`)

Signed-off-by: TophEvich <84676511+TophEvich@users.noreply.github.com>