### PR TITLE
Add support for macos 12.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ echo "Copying files..."
 
 cp -r "$SRC"/* "$PACKAGE/"
 cp "$ARTWORK/logos/icns/AsahiLinux_logomark.icns" "$PACKAGE/logo.icns"
-cp "$M1N1/build/m1n1.macho" "$PACKAGE"
+cp "$M1N1/build/m1n1.macho" "$M1N1/build/m1n1.bin" "$PACKAGE"
 
 echo "Extracting Python framework..."
 

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,11 @@ IPSW_VERSIONS = [
          "iBoot-7429.41.5",
          False,
          "https://updates.cdn-apple.com/2021FCSFall/fullrestores/002-23780/D3417F21-41BD-4DDF-9135-FA5A129AF6AF/UniversalMac_12.0.1_21A559_Restore.ipsw"),
+    IPSW("12.1",
+         "12.1",
+         "iBoot-7429.61.2",
+         False,
+         "https://updates.cdn-apple.com/2021FCSWinter/fullrestores/002-42433/F3F6D5CD-67FE-449C-9212-F7409808B6C4/UniversalMac_12.1_21C52_Restore.ipsw"),
 ]
 
 class InstallerMain:

--- a/src/step2.sh
+++ b/src/step2.sh
@@ -25,7 +25,12 @@ echo
 read
 
 bputil -nc -v "$VGID"
-kmutil configure-boot -c m1n1.macho -v "$system_dir"
+
+if [ -f m1n1.macho ]; then
+    kmutil configure-boot -c m1n1.macho -v "$system_dir"
+else
+    kmutil configure-boot -c m1n1.bin --raw --entry-point 2048 --lowest-virtual-address 0 -v "$system_dir"
+fi
 
 echo
 echo "Installation complete! Press enter to reboot."

--- a/src/stub.py
+++ b/src/stub.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: MIT
 import os, plistlib, shutil, sys, stat, subprocess, urlcache, zipfile
 import osenum
+from util import split_ver
 
 class Installer:
     def __init__(self, sysinfo, dutil, osinfo, ipsw_info):
         self.dutil = dutil
         self.sysinfo = sysinfo
         self.osinfo = osinfo
+        self.install_version = ipsw_info.version.split(maxsplit=1)[0]
         self.verbose = "-v" in sys.argv
 
         print("Downloading OS package info...")
@@ -182,7 +184,10 @@ class Installer:
         except:
             print("Failed to apply extended attributes, logo will not work.")
 
-        shutil.copy("m1n1.macho", os.path.join(self.osi.system))
+        if split_ver(self.install_version) < (12, 1):
+            shutil.copy("m1n1.macho", os.path.join(self.osi.system))
+        else:
+            shutil.copy("m1n1.bin", os.path.join(self.osi.system))
         step2_sh = open("step2.sh").read().replace("##VGID##", self.osi.vgid)
         step2_sh_dst = os.path.join(self.osi.system, "step2.sh")
         with open(step2_sh_dst, "w") as fd:


### PR DESCRIPTION
Add support for m1n1.bin and `kmutil --raw` for macOS. Avoiding OS version detection in `step2.sh` by copying either m1n1.macho or m1n1.bin. I did not want to spend time on that based on the assumption that pre 12.1 support will be dropped/hidden in the final installer.