### PR TITLE
Remove unsupported macos versions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -35,16 +35,6 @@ DEVICE_MIN_VER = {
 }
 
 IPSW_VERSIONS = [
-    IPSW("11.4",
-         "11.4",
-         "iBoot-6723.120.36",
-         True,
-         "http://updates-http.cdn-apple.com/2021SpringFCS/fullrestores/071-00710/AB478B0E-D78C-4DFE-9BDA-5497969A5272/UniversalMac_11.4_20F71_Restore.ipsw"),
-    IPSW("11.5.2",
-         "11.5", # guess?
-         "iBoot-6723.140.2",
-         True,
-         "https://updates.cdn-apple.com/2021SummerFCS/fullrestores/071-78715/CFEE4AA0-C104-479B-BDE1-3BFA1DFE710C/UniversalMac_11.5.2_20G95_Restore.ipsw"),
     IPSW("12.0 beta 5",
          "12.0",
          "iBoot-7429.30.8.0.4",

--- a/src/main.py
+++ b/src/main.py
@@ -35,16 +35,6 @@ DEVICE_MIN_VER = {
 }
 
 IPSW_VERSIONS = [
-    IPSW("12.0 beta 5",
-         "12.0",
-         "iBoot-7429.30.8.0.4",
-         False,
-         "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/071-80097/9F639C04-F128-4EC9-93D3-2AAE04F8A314/UniversalMac_12.0_21A5304g_Restore.ipsw"),
-    IPSW("12.0 beta 8",
-         "12.0",
-         "iBoot-7429.40.84.181.1",
-         False,
-         "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-03830/B8D1658D-A579-4479-BBB1-7CDEAF328303/UniversalMac_12.0_21A5534d_Restore.ipsw"),
     IPSW("12.0.1",
          "12.0",
          "iBoot-7429.41.5",


### PR DESCRIPTION
We do not want to support macOS 11.x and `step2.sh` does not work once the system recovery is updated to macOs 12.1 or later.
Remove macOS 12.0 beta as well since they are not signed anymore by Apple. Selecting those as startup disk requires changing the boot policy security mode to reduced security first.