### PR TITLE
Force the use of python3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ rm -f _test* _tkinter*
     
 echo "Copying certificates..."
 
-certs="$(python -c 'import certifi; print(certifi.where())')"
+certs="$(python3 -c 'import certifi; print(certifi.where())')"
 cp "$certs" "$PACKAGE/Frameworks/Python.framework/Versions/Current/etc/openssl/cert.pem"
 
 echo "Packaging installer..."


### PR DESCRIPTION
This fixes building the installer in macOS as the default python binary is python2 (included by macOS).
Moreover python2 is deprecated in macOS and the path forward is to specifically use python3 instead of the default python.
As far as I can see, pip (required to install certifi) is only available for python3 in homebrew.