### PR TITLE
Add a Dockerfile for easy building from macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian
+RUN apt-get update && apt-get install -y git build-essential cpio p7zip-full imagemagick python3-certifi wget device-tree-compiler bison flex libssl-dev bc
+
+WORKDIR asahi-installer
+COPY .git .git
+RUN git reset --hard HEAD
+
+RUN ./build.sh


### PR DESCRIPTION
Currently the installer doesn’t build from macOS anymore, so here is a dockerfile to easily give this option