### PR TITLE
diskutil.py: fix for empty Apple_APFS_RECOVERY

### DIFF
--- a/src/diskutil.py
+++ b/src/diskutil.py
@@ -99,6 +99,11 @@ class DiskUtil:
                 else:
                     continue
                 break
+
+        if part.container is None:
+           part.container = {}
+           part.container["Volumes"] = []
+           logging.info(f"{part.name} doesn't have any Volumes")
         
         return part
 


### PR DESCRIPTION
With this disk layout:
diskutil list
/dev/disk0 (internal):
   #:                       TYPE NAME                    SIZE       IDENTIFIER
   0:      GUID_partition_scheme                         500.3 GB   disk0
   1:             Apple_APFS_ISC ⁨⁩                        524.3 MB   disk0s1
   2:                 Apple_APFS ⁨Container disk3⁩         402.5 GB   disk0s2
                    (free space)                         91.9 GB    -
   3:        Apple_APFS_Recovery ⁨⁩                        5.4 GB     disk0s6

/dev/disk3 (synthesized):
   #:                       TYPE NAME                    SIZE       IDENTIFIER
   0:      APFS Container Scheme -                      +402.5 GB   disk3
                                 Physical Store disk0s2
   1:                APFS Volume ⁨Macintosh HD⁩            15.8 GB    disk3s1
   2:              APFS Snapshot ⁨com.apple.os.update-...⁩ 15.8 GB    disk3s1s1
   3:                APFS Volume ⁨Preboot⁩                 821.7 MB   disk3s2
   4:                APFS Volume ⁨Recovery⁩                845.2 MB   disk3s3
   5:                APFS Volume ⁨Data⁩                    331.2 GB   disk3s5
   6:                APFS Volume ⁨VM⁩                      1.1 GB     disk3s6

I got this error:
Collecting OS information...
Traceback (most recent call last):
  File "/private/tmp/asahi-install/main.py", line 476, in <module>
    InstallerMain().main()
  File "/private/tmp/asahi-install/main.py", line 356, in main
    self.osinfo.collect(self.parts)
  File "/private/tmp/asahi-install/osenum.py", line 56, in collect
    self.collect_recovery(p)
  File "/private/tmp/asahi-install/osenum.py", line 64, in collect_recovery
    for volume in part.container["Volumes"]:
TypeError: 'NoneType' object is not subscriptable

The commit fixes that by creating an empty container["Volumes"] if we couldn't
find a container.

Debugging help and suggested fix from nico_32 in irc