### PR TITLE
tools/wipe-linux: check for whitespace + 2.5GB

### DIFF
--- a/tools/wipe-linux.sh
+++ b/tools/wipe-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-diskutil list | grep Apple_APFS | grep '2\.5 GB' | sed 's/.* //g' | while read i; do
+diskutil list | grep Apple_APFS | grep '\s2\.5 GB' | sed 's/.* //g' | while read i; do
     diskutil apfs deleteContainer "$i"
 done
 diskutil list /dev/disk0 | grep -Ei 'asahi|linux|EFI' | sed 's/.* //g' | while read i; do


### PR DESCRIPTION
This previously detected my 402.5GB macos as a linux disk.
Let's make it slightly safer by checking for exactly 2.5GB

Note: if the macos disk is mounted it doesn't actually get deleted
Signed-off-by: Steffen Dirkwinkel <me@steffen.cc>