### PR TITLE
Expand linux root when installing from free space

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -143,16 +143,16 @@ class InstallerMain:
         logging.info(f"Creating stub macOS: {label}")
         self.part = self.dutil.addPartition(free_part.name, "apfs", label, STUB_SIZE)
 
-        self.do_install()
+        self.do_install(free_part.size - STUB_SIZE)
 
-    def do_install(self):
+    def do_install(self, free_part_size = None):
         print(f"Installing stub macOS into {self.part.name} ({self.part.label})")
 
         self.ins.prepare_volume(self.part)
         self.ins.check_volume()
         self.ins.install_files(self.cur_os)
 
-        self.osins.partition_disk(self.part.name)
+        self.osins.partition_disk(self.part.name, total_size=free_part_size)
 
         pkg = None
         if self.osins.needs_firmware:


### PR DESCRIPTION
When installing from free space the available size of the free chunk was
not being passed to the OSInstaller in order to extend the Linux rootfs
partition.

This passes (free_size - stub_size) to the OSInstaller so that it can
expand the linux root to cover all available space in that chunk.

Signed-off-by: Javier Alvarez <javier.alvarez@allthingsembedded.net>