### PR TITLE
Make it clear the initial resize is for the current MacOS partition

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -547,7 +547,7 @@ class InstallerMain:
 
         assert free > min_free
 
-        p_message(f"Resizing: {target.desc}")
+        p_message(f"Resizing: {target.desc}. This is going to be the new size of the main MacOS disk.")
         p_info(f"  Total size: {col()}{ssize(total)}")
         p_info(f"  Free space: {col()}{ssize(free)}")
         p_info(f"  Minimum free space: {col()}{ssize(min_free)}")


### PR DESCRIPTION
While installing Asahi for the first time today it wasn't really clear to me that what I was going to do was to resize the current MacOS partition / disk even though the word "Resizing" is the first one.

I thought it might be nice to the end user to be more explicit.