### PR TITLE
Fix UEFI environment only install

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -240,7 +240,7 @@ class InstallerMain:
         print()
         p_message(f"Available free space: {ssize(free_part.size)}")
 
-        os_size = None
+        os_size = min_size
         if self.osins.expandable:
             print()
             p_question("How much space should be allocated to the new OS?")


### PR DESCRIPTION
This fixes https://github.com/AsahiLinux/asahi-installer/issues/40 (TypeError exception when installing UEFI only environment).
UEFI env only install failed because os_size was iniitialized to None, and because it isn't exapandable, os_size was never set to anything...  
Fix: set os_size to min_size.  

I installed UEFI env successfully this way!