### PR TITLE
Use absolute path for commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-cd "$(dirname "$0")"
+/usr/bin/cd "$(dirname "$0")"
 
 PYTHON_VER=3.9.6
 PYTHON_PKG=python-$PYTHON_VER-macos11.pkg
@@ -17,72 +17,72 @@ PACKAGE="$PWD/package"
 RELEASES="$PWD/releases"
 RELEASES_DEV="$PWD/releases-dev"
 
-rm -rf "$PACKAGE"
+/bin/rm -rf "$PACKAGE"
 
-mkdir -p "$DL" "$PACKAGE" "$RELEASES" "$RELEASES_DEV"
-mkdir -p "$PACKAGE/bin"
+/bin/mkdir -p "$DL" "$PACKAGE" "$RELEASES" "$RELEASES_DEV"
+/bin/mkdir -p "$PACKAGE/bin"
 
-echo "Determining version..."
+/bin/echo "Determining version..."
 
-VER=$(git describe --always --dirty --tags)
+VER=$(/usr/bin/git describe --always --dirty --tags)
 
-echo "Version: $VER"
+/bin/echo "Version: $VER"
 
 if [ -z "$VER" ]; then
     if [ -e version.tag ]; then
-        VER="$(cat version.tag)"
+        VER="$(/bin/cat version.tag)"
     else
-        echo "Could not determine version!"
+        /bin/echo "Could not determine version!"
         exit 1
     fi
 fi
 
-echo "Downloading installer components..."
+/bin/echo "Downloading installer components..."
 
-cd "$DL"
+/usr/bin/cd "$DL"
 
 wget -Nc "$PYTHON_URI"
 
-echo "Building m1n1..."
+/bin/echo "Building m1n1..."
 
-make -C "$M1N1" RELEASE=1 CHAINLOADING=1 -j4
+/usr/bin/make -C "$M1N1" RELEASE=1 CHAINLOADING=1 -j4
 
-echo "Copying files..."
+/bin/echo "Copying files..."
 
-cp -r "$SRC"/* "$PACKAGE/"
-cp "$ARTWORK/logos/icns/AsahiLinux_logomark.icns" "$PACKAGE/logo.icns"
-mkdir -p "$PACKAGE/boot"
-cp "$M1N1/build/m1n1.bin" "$PACKAGE/boot"
+/bin/cp -r "$SRC"/* "$PACKAGE/"
+/bin/cp "$ARTWORK/logos/icns/AsahiLinux_logomark.icns" "$PACKAGE/logo.icns"
+/bin/mkdir -p "$PACKAGE/boot"
+/bin/cp "$M1N1/build/m1n1.bin" "$PACKAGE/boot"
 
-echo "Extracting Python framework..."
+/bin/echo "Extracting Python framework..."
 
-mkdir -p "$PACKAGE/Frameworks/Python.framework"
+/bin/mkdir -p "$PACKAGE/Frameworks/Python.framework"
 
-7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat | \
-    cpio -i -D "$PACKAGE/Frameworks/Python.framework"
+7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | /usr/bin/zcat | \
+    /usr/bin/cpio -i -D "$PACKAGE/Frameworks/Python.framework"
 
-echo "Slimming down Python..."
+/bin/echo "Slimming down Python..."
 
-cd "$PACKAGE/Frameworks/Python.framework/Versions/Current"
+/usr/bin/cd "$PACKAGE/Frameworks/Python.framework/Versions/Current"
 
-rm -rf include share
-cd lib
-rm -rf -- tdb* tk* Tk* libtk* *tcl*
-cd python3.*
-rm -rf test ensurepip idlelib
-cd lib-dynload
-rm -f _test* _tkinter*
+/bin/rm -rf include share
+/usr/bin/cd lib
+/bin/rm -rf -- tdb* tk* Tk* libtk* *tcl*
+/usr/bin/cd python3.*
+/bin/rm -rf test ensurepip idlelib
+/usr/bin/cd lib-dynload
+/bin/rm -f _test* _tkinter*
     
-echo "Copying certificates..."
+/bin/echo "Copying certificates..."
 
-certs="$(python3 -c 'import certifi; print(certifi.where())')"
-cp "$certs" "$PACKAGE/Frameworks/Python.framework/Versions/Current/etc/openssl/cert.pem"
+certs="$(/usr/bin/python3 -c 'import certifi; print(certifi.where())')"
+/bin/cp "$certs" "$PACKAGE/Frameworks/Python.framework/Versions/Current/etc/openssl/cert.pem"
 
-echo "Packaging installer..."
+/bin/echo "Packaging installer..."
 
-cd "$PACKAGE"
+/usr/bin/cd "$PACKAGE"
 
-echo "$VER" > version.tag
+/bin/echo "$VER" > version.tag
 
 if [ "$1" == "prod" ]; then
     PKGFILE="$RELEASES/installer-$VER.tar.gz"
@@ -95,8 +95,8 @@ else
     LATEST="../latest"
 fi
 
-tar czf "$PKGFILE" .
-echo "$VER" > "$LATEST"
+/usr/bin/tar czf "$PKGFILE" .
+/bin/echo "$VER" > "$LATEST"
 
-echo
-echo "Built package: $(basename "$PKGFILE")"
+/bin/echo
+/bin/echo "Built package: $(/usr/bin/basename "$PKGFILE")"

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -6,42 +6,42 @@ set -e
 export LANG=C
 export LC_ALL=C
 
-export VERSION_FLAG=https://cdn.asahilinux.org/installer-dev/latest
-export INSTALLER_BASE=https://cdn.asahilinux.org/installer-dev
+export VERSION_FLAG=https:///usr/bin/cdn.asahilinux.org/installer-dev/latest
+export INSTALLER_BASE=https:///usr/bin/cdn.asahilinux.org/installer-dev
 export INSTALLER_DATA=https://github.com/AsahiLinux/asahi-installer/raw/main/data/installer_data.json
-export REPO_BASE=https://cdn.asahilinux.org
+export REPO_BASE=https:///usr/bin/cdn.asahilinux.org
 
 #TMP="$(mktemp -d)"
 TMP=/tmp/asahi-install
 
-echo
-echo "Bootstrapping installer:"
+/bin/echo
+/bin/echo "Bootstrapping installer:"
 
-mkdir -p "$TMP"
-cd "$TMP"
+/bin/mkdir -p "$TMP"
+/usr/bin/cd "$TMP"
 
-echo "  Checking version..."
+/bin/echo "  Checking version..."
 
-PKG_VER="$(curl -s -L "$VERSION_FLAG")"
-echo "  Version: $PKG_VER"
+PKG_VER="$(/usr/bin/curl -s -L "$VERSION_FLAG")"
+/bin/echo "  Version: $PKG_VER"
 
 PKG="installer-$PKG_VER.tar.gz"
 
-echo "  Downloading..."
+/bin/echo "  Downloading..."
 
-curl -s -L -o "$PKG" "$INSTALLER_BASE/$PKG"
-curl -s -L -O "$INSTALLER_DATA"
+/usr/bin/curl -s -L -o "$PKG" "$INSTALLER_BASE/$PKG"
+/usr/bin/curl -s -L -O "$INSTALLER_DATA"
 
-echo "  Extracting..."
+/bin/echo "  Extracting..."
 
-tar xf "$PKG"
+/usr/bin/tar xf "$PKG"
 
-echo "  Initializing..."
-echo
+/bin/echo "  Initializing..."
+/bin/echo
 
 if [ "$USER" != "root" ]; then
-    echo "The installer needs to run as root."
-    echo "Please enter your sudo password if prompted."
+    /bin/echo "The installer needs to run as root."
+    /bin/echo "Please enter your sudo password if prompted."
     exec caffeinate -dis sudo -E ./install.sh "$@"
 else
     exec caffeinate -dis ./install.sh "$@"

--- a/scripts/bootstrap-prod.sh
+++ b/scripts/bootstrap-prod.sh
@@ -6,42 +6,42 @@ set -e
 export LANG=C
 export LC_ALL=C
 
-export VERSION_FLAG=https://cdn.asahilinux.org/installer/latest
-export INSTALLER_BASE=https://cdn.asahilinux.org/installer
+export VERSION_FLAG=https:///usr/bin/cdn.asahilinux.org/installer/latest
+export INSTALLER_BASE=https:///usr/bin/cdn.asahilinux.org/installer
 export INSTALLER_DATA=https://github.com/AsahiLinux/asahi-installer/raw/prod/data/installer_data.json
-export REPO_BASE=https://cdn.asahilinux.org
+export REPO_BASE=https:///usr/bin/cdn.asahilinux.org
 
 #TMP="$(mktemp -d)"
 TMP=/tmp/asahi-install
 
-echo
-echo "Bootstrapping installer:"
+/bin/echo
+/bin/echo "Bootstrapping installer:"
 
-mkdir -p "$TMP"
-cd "$TMP"
+/bin/mkdir -p "$TMP"
+/usr/bin/cd "$TMP"
 
-echo "  Checking version..."
+/bin/echo "  Checking version..."
 
-PKG_VER="$(curl -s -L "$VERSION_FLAG")"
-echo "  Version: $PKG_VER"
+PKG_VER="$(/usr/bin/curl -s -L "$VERSION_FLAG")"
+/bin/echo "  Version: $PKG_VER"
 
 PKG="installer-$PKG_VER.tar.gz"
 
-echo "  Downloading..."
+/bin/echo "  Downloading..."
 
-curl -s -L -o "$PKG" "$INSTALLER_BASE/$PKG"
-curl -s -L -O "$INSTALLER_DATA"
+/usr/bin/curl -s -L -o "$PKG" "$INSTALLER_BASE/$PKG"
+/usr/bin/curl -s -L -O "$INSTALLER_DATA"
 
-echo "  Extracting..."
+/bin/echo "  Extracting..."
 
-tar xf "$PKG"
+/usr/bin/tar xf "$PKG"
 
-echo "  Initializing..."
-echo
+/bin/echo "  Initializing..."
+/bin/echo
 
 if [ "$USER" != "root" ]; then
-    echo "The installer needs to run as root."
-    echo "Please enter your sudo password if prompted."
+    /bin/echo "The installer needs to run as root."
+    /bin/echo "Please enter your sudo password if prompted."
     exec caffeinate -dis sudo -E ./install.sh "$@"
 else
     exec caffeinate -dis ./install.sh "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,27 +14,27 @@ PKG=installer.tar.gz
 #TMP="$(mktemp -d)"
 TMP=/tmp/asahi-install
 
-echo
-echo "Bootstrapping installer:"
+/bin/echo
+/bin/echo "Bootstrapping installer:"
 
-mkdir -p "$TMP"
-cd "$TMP"
+/bin/mkdir -p "$TMP"
+/usr/bin/cd "$TMP"
 
-echo "  Downloading..."
+/bin/echo "  Downloading..."
 
-curl -s -L -O "$INSTALLER_BASE/$PKG"
-curl -s -L -O "$INSTALLER_DATA"
+/usr/bin/curl -s -L -O "$INSTALLER_BASE/$PKG"
+/usr/bin/curl -s -L -O "$INSTALLER_DATA"
 
-echo "  Extracting..."
+/bin/echo "  Extracting..."
 
-tar xf "$PKG"
+/usr/bin/tar xf "$PKG"
 
-echo "  Initializing..."
-echo
+/bin/echo "  Initializing..."
+/bin/echo
 
 if [ "$USER" != "root" ]; then
-    echo "The installer needs to run as root."
-    echo "Please enter your sudo password if prompted."
+    /bin/echo "The installer needs to run as root."
+    /bin/echo "Please enter your sudo password if prompted."
     exec caffeinate -dis sudo -E ./install.sh "$@"
 else
     exec caffeinate -dis ./install.sh "$@"

--- a/src/install.sh
+++ b/src/install.sh
@@ -14,18 +14,18 @@ export PATH="$PWD/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
 arch=
 
-if ! arch -arm64 ls >/dev/null 2>/dev/null; then
-    echo
-    echo "Looks like this is an Intel Mac!"
-    echo "Sorry, Asahi Linux only supports Apple Silicon machines."
-    echo "May we interest you in https://t2linux.org/ instead?"
+if ! /usr/bin/arch -arm64 /bin/ls >/dev/null 2>/dev/null; then
+    /bin/echo
+    /bin/echo "Looks like this is an Intel Mac!"
+    /bin/echo "Sorry, Asahi Linux only supports Apple Silicon machines."
+    /bin/echo "May we interest you in https://t2linux.org/ instead?"
     exit 1
 fi
 
-if [ $(arch) != "arm64" ]; then
-    echo
-    echo "You're running the installer in Intel mode under Rosetta!"
-    echo "Don't worry, we can fix that for you. Switching to ARM64 mode..."
+if [ $(/usr/bin/arch) != "arm64" ]; then
+    /bin/echo
+    /bin/echo "You're running the installer in Intel mode under Rosetta!"
+    /bin/echo "Don't worry, we can fix that for you. Switching to ARM64 mode..."
     arch="arch -arm64"
 fi
 

--- a/tools/cleanbp.sh
+++ b/tools/cleanbp.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 set -e
 
-cat > /tmp/uuids.txt <<EOF
+/bin/cat > /tmp/uuids.txt <<EOF
 3D3287DE-280D-4619-AAAB-D97469CA9C71
 C8858560-55AC-400F-BBB9-C9220A8DAC0D
 EOF
 
-diskutil apfs listVolumeGroups >> /tmp/uuids.txt
+/usr/sbin/diskutil apfs listVolumeGroups >> /tmp/uuids.txt
 
-cd /System/Volumes/iSCPreboot
+/usr/bin/cd /System/Volumes/iSCPreboot
 
 for i in ????????-????-????-????-????????????; do
-    if grep -q "$i" /tmp/uuids.txt; then
-        echo "KEEP $i"
+    if /usr/bin/grep -q "$i" /tmp/uuids.txt; then
+        /bin/echo "KEEP $i"
     else
-        echo "RM $i"
-        rm -rf "$i"
+        /bin/echo "RM $i"
+        /bin/rm -rf "$i"
     fi
 done

--- a/tools/wipe-linux.sh
+++ b/tools/wipe-linux.sh
@@ -1,27 +1,27 @@
 #!/bin/sh
 set -e
 
-diskutil list | grep Apple_APFS | grep '\b2\.5 GB' | sed 's/.* //g' | while read i; do
-    diskutil apfs deleteContainer "$i"
+/usr/sbin/diskutil list | /usr/bin/grep Apple_APFS | /usr/bin/grep '\b2\.5 GB' | /usr/bin/sed 's/.* //g' | while read i; do
+    /usr/sbin/diskutil apfs deleteContainer "$i"
 done
-diskutil list /dev/disk0 | grep -Ei 'asahi|linux|EFI' | sed 's/.* //g' | while read i; do
-    diskutil eraseVolume free free "$i"
+/usr/sbin/diskutil list /dev/disk0 | /usr/bin/grep -Ei 'asahi|linux|EFI' | /usr/bin/sed 's/.* //g' | while read i; do
+    /usr/sbin/diskutil eraseVolume free free "$i"
 done
 
-cat > /tmp/uuids.txt <<EOF
+/bin/cat > /tmp/uuids.txt <<EOF
 3D3287DE-280D-4619-AAAB-D97469CA9C71
 C8858560-55AC-400F-BBB9-C9220A8DAC0D
 EOF
 
-diskutil apfs listVolumeGroups >> /tmp/uuids.txt
+/usr/sbin/diskutil apfs listVolumeGroups >> /tmp/uuids.txt
 
-cd /System/Volumes/iSCPreboot
+/usr/bin/cd /System/Volumes/iSCPreboot
 
 for i in ????????-????-????-????-????????????; do
-    if grep -q "$i" /tmp/uuids.txt; then
-        echo "KEEP $i"
+    if /usr/bin/grep -q "$i" /tmp/uuids.txt; then
+        /bin/echo "KEEP $i"
     else
-        echo "RM $i"
-        rm -rf "$i"
+        /usr/bin/echo "RM $i"
+        /bin/rm -rf "$i"
     fi
 done


### PR DESCRIPTION
Hi,
Thanks for the amazing project!

I modified some shell scripts. This is because on macOS environments, we cannot guarantee that users use expected version of command line tools (Just calling `sed` (mkdir` `grep` ... on shellscript may launch GNU version of `sed` which was installed by user, whereas `sed` on macOS is BSD version). This may lead to troubles.

By the way, in the shell scripts, `wget` and `7z` are used without any validation. Those tools are not seen in default macOS installation, so is it okay to assume users of Asahi Linux have to install Homebrew or MacPorts (or similar package managers)?

----------
Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~@~ pm.me>
