### PR TITLE
Support for OS uninstall and partition grow

### DIFF
--- a/src/diskutil.py
+++ b/src/diskutil.py
@@ -9,6 +9,7 @@ class Partition:
     size: int
     free: bool
     type: str
+    free_space_after: int = 0
     uuid: str = None
     desc: str = None
     label: str = None
@@ -141,19 +142,26 @@ class DiskUtil:
             parts.append(self.get_partition_info(dskpart["DeviceIdentifier"]))
         parts.sort(key=lambda i: i.offset)
 
+        prev_part = None
         prev_name = dskname
         parts2 = []
         for part in parts:
-            if (part.offset - p) > self.FREE_THRESHOLD:
+            free_space = part.offset - p
+            if free_space > self.FREE_THRESHOLD:
                 parts2.append(Partition(name=prev_name, free=True, type=None,
-                                        offset=p, size=(part.offset - p)))
+                                        offset=p, size=free_space))
+                if prev_part is not None:
+                    prev_part.free_space_after = free_space
             parts2.append(part)
+            prev_part = part
             prev_name = part.name
             p = part.offset + part.size
 
-        if (total_size - p) > self.FREE_THRESHOLD:
+        free_space = total_size - p
+        if free_space > self.FREE_THRESHOLD:
             parts2.append(Partition(name=prev_name, free=True, type=None,
-                                    offset=p, size=(total_size - p)))
+                                    offset=p, size=free_space))
+            prev_part.free_space_after = free_space
         return parts2
 
     def refresh_part(self, part):

--- a/src/diskutil.py
+++ b/src/diskutil.py
@@ -197,6 +197,14 @@ class DiskUtil:
 
         raise Exception("Could not find new partition")
 
+    def deletePartition(self, part):
+        if part.type == "Apple_APFS":
+            logging.info(f"Deleting APFS partition {part.name}")
+            self.action("apfs", "deleteContainer", part.name, verbose=True)
+        else:
+            logging.info(f"Deleting non-APFS partition {part.name}")
+            self.action("eraseVolume", "free", "free", part.name, verbose=True)
+
     def changeVolumeRole(self, volume, role):
         self.action("apfs", "changeVolumeRole", volume, role, verbose=True)
 


### PR DESCRIPTION
Add the following options to the installer:
 * Delete arbitrary partitions (expert mode)
 * Uninstall Asahi by removing the stub partition, the corresponding ESP, and (optionally) the Linux partitions directly following it
 * Grow an APFS container to use the free space after it.

Implements #83.