### PR TITLE
Check if a partition is a container

### DIFF
--- a/src/diskutil.py
+++ b/src/diskutil.py
@@ -123,11 +123,6 @@ class DiskUtil:
                     continue
                 break
 
-        if part.container is None:
-           part.container = {}
-           part.container["Volumes"] = []
-           logging.info(f"{part.name} doesn't have any Volumes")
-
         logging.debug(f"Partition {dev}: {part}")
         return part
 

--- a/src/main.py
+++ b/src/main.py
@@ -734,13 +734,16 @@ class InstallerMain:
                     p.desc += " (System Recovery)"
                 if p.label is not None:
                     p.desc += f" [{p.label}]"
-                vols = p.container["Volumes"]
-                p.desc += f" ({ssize(p.size)}, {len(vols)} volume{'s' if len(vols) != 1 else ''})"
-                if self.can_resize(p):
-                    parts_resizable.append(p)
+                if p.container is None:
+                    p.desc += f" (not a container)"
                 else:
-                    if p.size >= STUB_SIZE * 0.95:
-                        parts_empty_apfs.append(p)
+                    vols = p.container["Volumes"]
+                    p.desc += f" ({ssize(p.size)}, {len(vols)} volume{'s' if len(vols) != 1 else ''})"
+                    if self.can_resize(p):
+                        parts_resizable.append(p)
+                    else:
+                        if p.size >= STUB_SIZE * 0.95:
+                            parts_empty_apfs.append(p)
             else:
                 p.desc = f"{p.type} ({ssize(p.size)})"
 

--- a/src/osenum.py
+++ b/src/osenum.py
@@ -65,6 +65,9 @@ class OSEnum:
 
     def collect_recovery(self, part):
         logging.info(f"OSEnum.collect_recovery(part={part.name})")
+        if part.container is None:
+            return
+
         recs = []
 
         for volume in part.container["Volumes"]:


### PR DESCRIPTION
The Asahi Linux installer assumes a partition whose type is APFS is a container, but it sometimes turns otherwise because it is not formatted, for example.

Commit b550d86cf81d64449eff776d6b201245ff3ca9eb tried to solve the issue by filling `Partition.container` with a dictionary containing empty `Volumes` property. However, it broke some existing code checking if `Partition.container` is `None`. Particularly, it broke `InstallerMain.can_resize` which has such check, and accesses `CapacityFree` property.

It is difficult to fill `Partition.container` with a dummy dictionary containing lots of properties which an actual container can have, and it cannot prevent from perform some operation on the non-existing container.

This change removes the dummy dictionary and instead adds code to check if `Partition.container` is `None` to every place where assumption that a partition is a container is made. Fortunately, there are only three such places; namely, `OSEnum.collect_recovery`, `OSEnum.collect_part`, and `OSEnum.main_loop`. `OSEnum.collect_part` already has such a check.

Signed-off-by: Akihiko Odaki \<akihiko.odaki@gmail.com\>