### PR TITLE
asahi_fwextract: add console entrypoint

### DIFF
--- a/asahi_firmware/update.py
+++ b/asahi_firmware/update.py
@@ -35,7 +35,7 @@ def update_firmware(source, dest):
 
     pkg.save_manifest(os.path.join(dest, "manifest.txt"))
 
-if __name__ == "__main__":
+def main():
     import argparse
     import logging
     logging.basicConfig()
@@ -49,3 +49,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     update_firmware(args.source, args.dest)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(name='asahi_firmware',
       author_email='marcan@marcan.st',
       url='https://github.com/AsahiLinux/asahi-installer/',
       packages=['asahi_firmware'],
+      entry_points={"console_scripts": ["asahi-fwextract = asahi_firmware.update:main"]}
      )


### PR DESCRIPTION
Allows scripts and users to simply run the command `asahi-fwextract` instead of invoking the module with Python directly.