### PR TITLE
Make Asahi Linux volume hidden on the desktop

### DIFF
--- a/src/step2/step2.sh
+++ b/src/step2/step2.sh
@@ -131,6 +131,8 @@ if [ -e "$system_dir/System/Library/CoreServices/SystemVersion-disabled.plist" ]
     mv -f "$system_dir/System/Library/CoreServices/SystemVersion"{-disabled,}".plist"
 fi
 
+chflags hidden "$system_dir"
+
 echo
 echo "Installation complete! Press enter to reboot."
 read


### PR DESCRIPTION
This makes it so if the user enables show hard disks on the desktop it won't show the Asahi Linux stub volume.