### PR TITLE
asahi_firmware.img4: Add an entrypoint

### DIFF
--- a/asahi_firmware/img4.py
+++ b/asahi_firmware/img4.py
@@ -75,3 +75,11 @@ def img4p_extract(data):
     decoder = asn1.Decoder()
     decoder.start(data)
     return decode_header(decoder)
+
+if __name__ == "__main__":
+    import sys
+
+    data = open(sys.argv[1], "rb").read()
+    name, raw = img4p_extract_compressed(data)
+    with open(sys.argv[2], "wb") as fd:
+        fd.write(raw)

--- a/asahi_firmware/img4.py
+++ b/asahi_firmware/img4.py
@@ -52,12 +52,15 @@ def decode_header(decoder):
 
     return name, data
 
-def img4p_extract_compressed(data):
+def img4p_extract(data):
     decoder = asn1.Decoder()
     decoder.start(data)
     name, cdata = decode_header(decoder)
 
     tag = decoder.peek()
+    if tag is None:
+        return name, cdata
+
     assert tag.nr == asn1.Numbers.Sequence
     assert tag.typ == asn1.Types.Constructed
     decoder.enter()
@@ -71,15 +74,10 @@ def img4p_extract_compressed(data):
 
     return name, decode_lzfse(cdata, raw_size)
 
-def img4p_extract(data):
-    decoder = asn1.Decoder()
-    decoder.start(data)
-    return decode_header(decoder)
-
 if __name__ == "__main__":
     import sys
 
     data = open(sys.argv[1], "rb").read()
-    name, raw = img4p_extract_compressed(data)
+    name, raw = img4p_extract(data)
     with open(sys.argv[2], "wb") as fd:
         fd.write(raw)

--- a/asahi_firmware/kernel.py
+++ b/asahi_firmware/kernel.py
@@ -26,7 +26,7 @@ class KernelFWCollection(object):
 
         with open(kern_path, "rb") as fd:
             im4p = fd.read()
-        name, kernel = img4p_extract_compressed(im4p)
+        name, kernel = img4p_extract(im4p)
 
         for fwf in extract_asmedia(kernel):
             self.fwfiles.append((fwf.name, fwf))


### PR DESCRIPTION
This works as a replacement for img4tool with fewer dependencies.