### PR TITLE
Prepare installer for macOS 13.5

### DIFF
--- a/asahi_firmware/multitouch.py
+++ b/asahi_firmware/multitouch.py
@@ -81,6 +81,8 @@ def plist_to_bin_trackpad(plist):
     for i in plist:
         if i["Type"] == "Config":
             for j in i["Config"]["Interface Config"]:
+                if "HIDRecorder Descriptor" in j.keys():
+                    continue
                 j["bInterfaceNumber"] = None
 
     def serialize(o):

--- a/src/main.py
+++ b/src/main.py
@@ -65,6 +65,10 @@ DEVICES = {
     "j416sap":  Device("13.2", True),  # MacBook Pro (16-inch, M2 Pro, 2023)
     "j473ap":   Device("13.2", True),  # Mac mini (M2, 2023)
     "j474sap":  Device("13.2", True),  # Mac mini (M2 Pro, 2023)
+    "j415ap":   Device("13.4", True),  # MacBook Air (15-inch, M2, 2023)
+    "j475cap":  Device("13.4", True),  # Mac Studio (M2 Max, 2023)
+    "j475dap":  Device("13.4", True),  # Mac Studio (M2 Ultra, 2023)
+    "j180dap":  Device("13.4", True),  # Mac Pro (M2 Ultra, 2023)
 }
 
 IPSW_VERSIONS = [


### PR DESCRIPTION
- use 13.5 as only stub version, all others are downgraded to expert mode
- add missing devices (expert mode only)
- bump m1n1 to 1.3.0
- contains @WhatAmISupposedToPutHere touchbar firmware extraction from #173
- workaround for j415 trackpad plist (untested)