### PR TITLE
Check ucache exists before reconnecting

### DIFF
--- a/src/osinstall.py
+++ b/src/osinstall.py
@@ -103,7 +103,8 @@ class OSInstaller(PackageInstaller):
         logging.info("OSInstaller.install()")
 
         # Force a reconnect, since the connection is likely to have timed out
-        self.ucache.close_connection()
+        if self.ucache:
+            self.ucache.close_connection()
 
         icon = self.template.get("icon", None)
         if icon:


### PR DESCRIPTION
Building using `build.sh dev` doesn't download files, so ucache is none.

This checks that ucache exists before reconnecting.

Without this, you'll receive an error when running locally.