### PR TITLE
When using "external_boot" mode list all the possible OSes to install

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -486,8 +486,6 @@ class InstallerMain:
         os_list = self.data["os_list"]
         if not self.expert:
             os_list = [i for i in os_list if not i.get("expert", False)]
-        if self.cur_disk != self.sys_disk:
-            os_list = [i for i in os_list if i.get("external_boot", False)]
         p_question("Choose an OS to install:")
         idx = self.choice("OS", [i["name"] for i in os_list])
         os = os_list[idx]


### PR DESCRIPTION
If a user would like to install Asahi to external media and selects this under expert mode, they are left with no list of OSes to choose from, if they are hoping to use images from online sources to use. With these lines removed the full list exists, just like any other install.