### PR TITLE
Update Python version for security reasons

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-PYTHON_VER=3.9.6
+PYTHON_VER=3.11.5
 PYTHON_PKG=python-$PYTHON_VER-macos11.pkg
 PYTHON_URI="https://www.python.org/ftp/python/$PYTHON_VER/$PYTHON_PKG"
 


### PR DESCRIPTION
We should change the Python version for security reasons, 3.9.6 has minute flaws that could lead to a reverse shell exploit. I have followed all the links and the package remains valid,