### PR TITLE
Fix m1n1 installation (in expert mode)

### DIFF
--- a/src/osinstall.py
+++ b/src/osinstall.py
@@ -120,7 +120,8 @@ class OSInstaller(PackageInstaller):
         logging.info("OSInstaller.install()")
 
         # Force a reconnect, since the connection is likely to have timed out
-        self.ucache.close_connection()
+        if self.ucache is not None:
+            self.ucache.close_connection()
 
         icon = self.template.get("icon", None)
         if icon:


### PR DESCRIPTION
When installing m1n1, no package needs to be downloaded and the URL cache is None, triggering an exception when close_connection is called on it.