### PR TITLE
asahi_firmware.img4: Try lzfse SOVERSION 1 first

### DIFF
--- a/asahi_firmware/img4.py
+++ b/asahi_firmware/img4.py
@@ -6,7 +6,10 @@ from ctypes import *
 __all__ = ["img4p_extract_compressed", "img4p_extract"]
 
 def decode_lzfse_liblzfse(cdata, raw_size):
-    lzfse = CDLL("liblzfse.so")
+    try:
+        lzfse = CDLL("liblzfse.so.1")
+    except OSError:
+        lzfse = CDLL("liblzfse.so")
 
     dest = create_string_buffer(raw_size)
     decoded = lzfse.lzfse_decode_buffer(dest, raw_size, cdata, len(cdata), None)


### PR DESCRIPTION
Upstream lzfse library has no SOVERSION set, but distributions with library packaging guidelines wants them.

Fedora[1] [2] is apparently already using SOVERSION 1 (and patching this file using sed on package builds). Debian[3] is about to do the same.

Try first to load liblzfse.so.1 and if not found, fall back on the unversioned soname as before. This should make everyone happy without having to patch it everywhere.

[1]: https://src.fedoraproject.org/rpms/lzfse/blob/rawhide/f/60.patch
[2]: https://src.fedoraproject.org/rpms/asahi-installer/blob/fb68ade87292d3210fbe8845da829add6b1187c4/f/asahi-installer.spec#_54
[3]: https://salsa.debian.org/bananas-team/lzfse/-/blob/debian/unstable/debian/patches/0001-debian-set-library-SONAME.patch