### PR TITLE
utils.py: raise error if rootfs file size is not multiple of 4KiB.

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -149,6 +149,8 @@ class PackageInstaller:
         self.pkg.extract(src, dest)
 
     def fdcopy(self, sfd, dfd, size=None):
+        if size is not None and size % (4 * 1024) != 0:
+            raise Exception("The size of the rootfs image file must be a multiple of 4KiB.")
         BLOCK = 16 * 1024 * 1024
         copied = 0
         bps = 0


### PR DESCRIPTION
See: https://github.com/AOSC-Dev/aosc-asahi-installer/commit/c5c8633865c4369b14cade8bc2c1e43026d1207a, if rootfs image size can not multipie of 16MiB, asahi-installer will raise `EINVAL`, users don't know whats happen ...

The point of this commit is to look for illegitimate rootfs image sizes in advance, so that the raise error becomes clear.