### PR TITLE
Bump Fedora Boot partition size to 1GiB

### DIFF
--- a/data/installer_data.json
+++ b/data/installer_data.json
@@ -27,7 +27,7 @@
                 {
                     "name": "Boot",
                     "type": "Linux",
-                    "size": "1048576000B",
+                    "size": "1073741824B",
                     "image": "boot.img"
                 },
                 {
@@ -66,7 +66,7 @@
                 {
                     "name": "Boot",
                     "type": "Linux",
-                    "size": "1048576000B",
+                    "size": "1073741824B",
                     "image": "boot.img"
                 },
                 {
@@ -101,7 +101,7 @@
                 {
                     "name": "Boot",
                     "type": "Linux",
-                    "size": "1048576000B",
+                    "size": "1073741824B",
                     "image": "boot.img"
                 },
                 {
@@ -136,7 +136,7 @@
                 {
                     "name": "Boot",
                     "type": "Linux",
-                    "size": "1048576000B",
+                    "size": "1073741824B",
                     "image": "boot.img"
                 },
                 {


### PR DESCRIPTION
Required after
https://pagure.io/fedora-asahi/kiwi-descriptions/c/ed3c8ba8c6d893de5b549308b6ba090d719b0eaf

Fixes: a908095 ("installer_data: Bump Fedora images to 202312190352")