### PR TITLE
remove the 12.4 IPSW

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -74,14 +74,6 @@ DEVICES = {
 }
 
 IPSW_VERSIONS = [
-    # This is the special M2 version, it comes ahead so it isn't the default in expert mode
-    IPSW("12.4",
-         "12.1",
-         "iBoot-7459.121.3",
-         "21.6.81.2.0,0",
-         False,
-         {"j413ap", "j493ap"},
-         "https://updates.cdn-apple.com/2022SpringFCS/fullrestores/012-17781/F045A95A-44B4-4BA9-8A8A-919ECCA2BB31/UniversalMac_12.4_21F2081_Restore.ipsw"),
     IPSW("12.3.1",
          "12.1",
          "iBoot-7459.101.3",


### PR DESCRIPTION
In a previous commit from December 23, 2023, Hector removed the ability to install 12.4 even in expert mode.

https://github.com/AsahiLinux/asahi-installer/commit/8bbbb8ca5a347d99b243e10f24358573f1587df0

This suggests that the 12.4 IPSW is no longer necessary. Remove it.