### PR TITLE
rm wget dependency, update python pkg slightly.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-PYTHON_VER=3.9.6
+PYTHON_VER=3.9.13
 PYTHON_PKG=python-$PYTHON_VER-macos11.pkg
 PYTHON_URI="https://www.python.org/ftp/python/$PYTHON_VER/$PYTHON_PKG"
 
@@ -43,7 +43,7 @@ echo "Downloading installer components..."
 
 cd "$DL"
 
-wget -Nc "$PYTHON_URI"
+curl "$PYTHON_URI" > "$PYTHON_PKG"
 
 echo "Building m1n1..."
 


### PR DESCRIPTION
remove wget dependency; use curl since it is a given on macOS.
Update python to 3.9.13 which is the most recent 3.9.x build with a prebuilt macosx pkg on https://www.python.org/ftp/python/

TODO: update to 3.9.18? 3.12? 3.13?