### PR TITLE
asahi_firmware: fallback to the system asn1

### DIFF
--- a/asahi_firmware/img4.py
+++ b/asahi_firmware/img4.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
 import sys
-from . import asn1
+try:
+    from . import asn1
+except ImportError:
+    import asn1
 from ctypes import *
 
 __all__ = ["img4p_extract_compressed", "img4p_extract"]


### PR DESCRIPTION
In Fedora we unbundle `asn1` for `python-asahi_firmware` (which is the module installed on the system and used by `asahi-scripts`), this should make that work without having to patch the import.