### PR TITLE
toil: update all shell scripts to pass shfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.sh]
+indent_style = space
+indent_size = 2
+

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,101 @@
+name: Static Analysis
+
+on: [push, pull_request]
+
+jobs:
+  apple-bash:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Install Shfmt
+        run: sudo apt-get install -y shfmt
+
+      - name: Run ShellCheck
+        run: |
+          find . -name "*.sh" -print0 | xargs -0 shellcheck --shell=bash | tee shellcheck-output.txt || true
+        continue-on-error: true
+
+      - name: Upload ShellCheck results
+        uses: actions/upload-artifact@v4
+        with:
+          name: shellcheck-results
+          path: shellcheck-output.txt
+
+      - name: Run Shfmt
+        run: |
+          shfmt -d -i 2 -ci -kp -s -sr . | tee shfmt-output.txt
+        continue-on-error: true
+
+      - name: Upload Shfmt results
+        uses: actions/upload-artifact@v4
+        with:
+          name: shfmt-results
+          path: shfmt-output.txt
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 bandit
+
+      - name: Run Flake8
+        run: |
+          flake8 . --output-file=flake8-output.txt || true
+        continue-on-error: true
+
+      - name: Upload Flake8 results
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake8-results
+          path: flake8-output.txt
+
+      - name: Run Bandit
+        run: |
+          bandit -r . -o bandit-output.txt -f txt || truefe
+        continue-on-error: true
+
+      - name: Upload Bandit results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-results
+          path: bandit-output.txt
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install yamllint
+        run: |
+          pip install yamllint
+
+      - name: Run yamllint
+        run: |
+          yamllint . > yamllint-output.txt || true
+
+      - name: Upload yamllint results
+        uses: actions/upload-artifact@v4
+        with:
+          name: yamllint-results
+          path: yamllint-output.txt

--- a/build.sh
+++ b/build.sh
@@ -34,12 +34,12 @@ echo "Determining version..."
 [ -d .git ] && VER=$(git describe --always --dirty --tags)
 
 if [ -z "$VER" ]; then
-    if [ -e version.tag ]; then
-        VER="$(cat version.tag)"
-    else
-        echo "Could not determine version!"
-        exit 1
-    fi
+  if [ -e version.tag ]; then
+    VER="$(cat version.tag)"
+  else
+    echo "Could not determine version!"
+    exit 1
+  fi
 fi
 
 echo "Version: $VER"
@@ -51,63 +51,64 @@ cd "$DL"
 echo " - Python"
 
 if [ -e "$PYTHON_PKG" ]; then
-    echo "Using existing $PYTHON_PKG"
+  echo "Using existing $PYTHON_PKG"
 else
-    wget -Nc "$PYTHON_URI"
+  wget -Nc "$PYTHON_URI"
 fi
 
 echo " - libffi"
 
 if [ -e "$LIBFFI_PKG" ]; then
-    echo "Using existing $LIBFFI_PKG"
+  echo "Using existing $LIBFFI_PKG"
 else
-    # get a JSON with an anonymous token
-    token=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository%3Ahomebrew/core/go%3Apull" | jq -jr ".token")
+  # get a JSON with an anonymous token
+  token=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository%3Ahomebrew/core/go%3Apull" | jq -jr ".token")
 
-    digest=$( \
-        curl -s \
-        -H "Authorization: Bearer ${token}" \
-        -H 'Accept: application/vnd.oci.image.index.v1+json' \
-        $LIBFFI_MANIFEST_URI \
-        | jq -r '[.manifests[] |
-                select(.platform.architecture == "arm64"
-                and .platform."os.version" == "'"$LIBFFI_TARGET_OS"'")
-            ] | first | .annotations."sh.brew.bottle.digest"' \
-    )
+  digest=$(
+    curl -s \
+      -H "Authorization: Bearer ${token}" \
+      -H 'Accept: application/vnd.oci.image.index.v1+json' \
+      $LIBFFI_MANIFEST_URI |
+      jq -r '[
+          .manifests[] |
+          select(.platform.architecture == "arm64"
+          and .platform."os.version" == "'"$LIBFFI_TARGET_OS"'")
+        ] | first | .annotations."sh.brew.bottle.digest"'
+  )
 
-    curl -L -o "$LIBFFI_PKG" \
-        -H "Authorization: Bearer ${token}" \
-        -H 'Accept: application/vnd.oci.image.index.v1+json' \
-        "$LIBFFI_BASE_URI/sha256:$digest"
+  curl -L -o "$LIBFFI_PKG" \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    "$LIBFFI_BASE_URI/sha256:$digest"
 fi
 
 if [ -r "$M1N1_STAGE1" ]; then
-    echo "Using '$M1N1_STAGE1' as m1n1 stage1"
+  echo "Using '$M1N1_STAGE1' as m1n1 stage1"
 elif [ ! -r "$M1N1/Makefile" ]; then
-    echo "m1n1 missing, did you forget to update the submodules?"
-    exit 1
+  echo "m1n1 missing, did you forget to update the submodules?"
+  exit 1
 else
-    echo "Building m1n1..."
+  echo "Building m1n1..."
 
-    # Do it twice in case of build system shenanigans with versions
-    make -C "$M1N1" RELEASE=1 CHAINLOADING=1 -j4
-    make -C "$M1N1" RELEASE=1 CHAINLOADING=1 -j4
+  # Do it twice in case of build system shenanigans with versions
+  make -C "$M1N1" RELEASE=1 CHAINLOADING=1 -j4
+  make -C "$M1N1" RELEASE=1 CHAINLOADING=1 -j4
 
-    M1N1_STAGE1="$M1N1/build/m1n1.bin"
+  M1N1_STAGE1="$M1N1/build/m1n1.bin"
 fi
 
 echo "Copying files..."
 
 cp -r "$SRC"/* "$PACKAGE/"
-rm "$PACKAGE/asahi_firmware"
+rm -rf "$PACKAGE/asahi_firmware"
 cp -r "$AFW" "$PACKAGE/"
 if [ -r "$LOGO" ]; then
-    cp "$LOGO" "$PACKAGE/logo.icns"
+  cp "$LOGO" "$PACKAGE/logo.icns"
 elif [ ! -r "$ARTWORK/logos/icns/AsahiLinux_logomark.icns" ]; then
-    echo "artwork missing, did you forget to update the submodules?"
-    exit 1
+  echo "artwork missing, did you forget to update the submodules?"
+  exit 1
 else
-    cp "$ARTWORK/logos/icns/AsahiLinux_logomark.icns" "$PACKAGE/logo.icns"
+  cp "$ARTWORK/logos/icns/AsahiLinux_logomark.icns" "$PACKAGE/logo.icns"
 fi
 mkdir -p "$PACKAGE/boot"
 cp "$M1N1_STAGE1" "$PACKAGE/boot/m1n1.bin"
@@ -121,9 +122,11 @@ echo "Extracting Python framework..."
 
 mkdir -p "$PACKAGE/Frameworks/Python.framework"
 
-7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat | \
-    cpio -i -D "$PACKAGE/Frameworks/Python.framework"
-
+7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat |
+  ( 
+    cd "$PACKAGE/Frameworks/Python.framework"
+    cpio -i
+  )
 
 cd "$PACKAGE/Frameworks/Python.framework/Versions/Current"
 
@@ -141,7 +144,6 @@ cd python3.*
 rm -rf test ensurepip idlelib
 cd lib-dynload
 rm -f _test* _tkinter*
-    
 
 echo "Copying certificates..."
 

--- a/push.sh
+++ b/push.sh
@@ -8,28 +8,33 @@ BASEPATH=https://storage.bunnycdn.com/asahilinux
 SRC=releases
 
 case "$1" in
-    prod) DIR=installer;;
-    dev) DIR=installer-dev;;
-    *) echo "Usage: $0 [prod|dev]" 1>&2; exit 1;;
+  prod) DIR=installer ;;
+  dev) DIR=installer-dev ;;
+  *)
+     echo "Usage: $0 [prod|dev]" 1>&2
+     exit 1
+     ;;
 esac
 
 if [ ! -e "$SECRET_FILE" ]; then
-    echo "Missing storage bucket secret. Please place the secret in $SECRET_FILE." 1>&2
-    exit 1
+  echo "Missing storage bucket secret. Please place the secret in $SECRET_FILE." 1>&2
+  exit 1
 fi
 
 SECRET="$(cat "$SECRET_FILE")"
 
 put() {
-    curl -# --fail --request PUT \
-        --url "$1" \
-        --header "AccessKey: $SECRET" \
-        --header "Content-Type: $2" \
-        --header 'accept: application/json'  \
-        --data-binary @$3 >/tmp/ret
-    ret=$?
-    cat /tmp/ret; echo; echo
-    return $ret
+  curl -# --fail --request PUT \
+    --url "$1" \
+    --header "AccessKey: $SECRET" \
+    --header "Content-Type: $2" \
+    --header 'accept: application/json' \
+    --data-binary @$3 > /tmp/ret
+  ret=$?
+  cat /tmp/ret
+  echo
+  echo
+  return $ret
 }
 
 VERSION="$(cat $SRC/latest)"
@@ -38,8 +43,8 @@ SRCFILE="$SRC/$FILE"
 TARGETFILE="$BASEPATH/$DIR/$FILE"
 
 if [ ! -e "$SRCFILE" ]; then
-    echo "$SRCFILE does not exist" 1>&2
-    exit 1
+  echo "$SRCFILE does not exist" 1>&2
+  exit 1
 fi
 
 echo "About to push version $VERSION from $SRCFILE to $TARGETFILE."

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -3,64 +3,64 @@
 
 # Truncation guard
 if true; then
-    set -e
+  set -e
 
-    if [ ! -e /System ]; then
-        echo "You appear to be running this script from Linux or another non-macOS system."
-        echo "Asahi Linux can only be installed from macOS (or recoveryOS)."
-        exit 1
-    fi
+  if [ ! -e /System ]; then
+    echo "You appear to be running this script from Linux or another non-macOS system."
+    echo "Asahi Linux can only be installed from macOS (or recoveryOS)."
+    exit 1
+  fi
 
-    export LC_ALL=en_US.UTF-8
-    export LANG=en_US.UTF-8
-    export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+  export LC_ALL=en_US.UTF-8
+  export LANG=en_US.UTF-8
+  export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-    export VERSION_FLAG=https://cdn.asahilinux.org/installer-dev/latest
-    export INSTALLER_BASE=https://cdn.asahilinux.org/installer-dev
-    export INSTALLER_DATA=https://github.com/AsahiLinux/asahi-installer/raw/main/data/installer_data.json
-    export REPO_BASE=https://cdn.asahilinux.org
-    export REPORT=https://stats.asahilinux.org/report
-    export REPORT_TAG=alx-dev
+  export VERSION_FLAG=https://cdn.asahilinux.org/installer-dev/latest
+  export INSTALLER_BASE=https://cdn.asahilinux.org/installer-dev
+  export INSTALLER_DATA=https://github.com/AsahiLinux/asahi-installer/raw/main/data/installer_data.json
+  export REPO_BASE=https://cdn.asahilinux.org
+  export REPORT=https://stats.asahilinux.org/report
+  export REPORT_TAG=alx-dev
 
-    export EXPERT=1
+  export EXPERT=1
 
-    #TMP="$(mktemp -d)"
-    TMP=/tmp/asahi-install
+  #TMP="$(mktemp -d)"
+  TMP=/tmp/asahi-install
 
-    echo
-    echo "Bootstrapping installer:"
+  echo
+  echo "Bootstrapping installer:"
 
-    if [ -e "$TMP" ]; then
-        mv "$TMP" "$TMP-$(date +%Y%m%d-%H%M%S)"
-    fi
+  if [ -e "$TMP" ]; then
+    mv "$TMP" "$TMP-$(date +%Y%m%d-%H%M%S)"
+  fi
 
-    mkdir -p "$TMP"
-    cd "$TMP"
+  mkdir -p "$TMP"
+  cd "$TMP"
 
-    echo "  Checking version..."
+  echo "  Checking version..."
 
-    PKG_VER="$(curl --no-progress-meter -L "$VERSION_FLAG")"
-    echo "  Version: $PKG_VER"
+  PKG_VER="$(curl --no-progress-meter -L "$VERSION_FLAG")"
+  echo "  Version: $PKG_VER"
 
-    PKG="installer-$PKG_VER.tar.gz"
+  PKG="installer-$PKG_VER.tar.gz"
 
-    echo "  Downloading..."
+  echo "  Downloading..."
 
-    curl --no-progress-meter -L -o "$PKG" "$INSTALLER_BASE/$PKG"
-    curl --no-progress-meter -L -O "$INSTALLER_DATA"
+  curl --no-progress-meter -L -o "$PKG" "$INSTALLER_BASE/$PKG"
+  curl --no-progress-meter -L -O "$INSTALLER_DATA"
 
-    echo "  Extracting..."
+  echo "  Extracting..."
 
-    tar xf "$PKG"
+  tar xf "$PKG"
 
-    echo "  Initializing..."
-    echo
+  echo "  Initializing..."
+  echo
 
-    if [ "$USER" != "root" ]; then
-        echo "The installer needs to run as root."
-        echo "Please enter your sudo password if prompted."
-        exec caffeinate -dis sudo -E ./install.sh "$@"
-    else
-        exec caffeinate -dis ./install.sh "$@"
-    fi
+  if [ "$USER" != "root" ]; then
+    echo "The installer needs to run as root."
+    echo "Please enter your sudo password if prompted."
+    exec caffeinate -dis sudo -E ./install.sh "$@"
+  else
+      exec caffeinate -dis ./install.sh "$@"
+  fi
 fi

--- a/scripts/bootstrap-prod.sh
+++ b/scripts/bootstrap-prod.sh
@@ -3,68 +3,68 @@
 
 # Truncation guard
 if true; then
-    set -e
+  set -e
 
-    if [ ! -e /System ]; then
-        echo "You appear to be running this script from Linux or another non-macOS system."
-        echo "Asahi Linux can only be installed from macOS (or recoveryOS)."
-        exit 1
-    fi
+  if [ ! -e /System ]; then
+    echo "You appear to be running this script from Linux or another non-macOS system."
+    echo "Asahi Linux can only be installed from macOS (or recoveryOS)."
+    exit 1
+  fi
 
-    export LC_ALL=en_US.UTF-8
-    export LANG=en_US.UTF-8
-    export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+  export LC_ALL=en_US.UTF-8
+  export LANG=en_US.UTF-8
+  export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-    export VERSION_FLAG=https://cdn.asahilinux.org/installer/latest
-    export INSTALLER_BASE=https://cdn.asahilinux.org/installer
-    export INSTALLER_DATA=https://github.com/AsahiLinux/asahi-installer/raw/prod/data/installer_data.json
-    export INSTALLER_DATA_ALT=https://alx.sh/installer_data.json
-    export REPO_BASE=https://cdn.asahilinux.org
-    export REPORT=https://stats.asahilinux.org/report
-    export REPORT_TAG=alx-prod
+  export VERSION_FLAG=https://cdn.asahilinux.org/installer/latest
+  export INSTALLER_BASE=https://cdn.asahilinux.org/installer
+  export INSTALLER_DATA=https://github.com/AsahiLinux/asahi-installer/raw/prod/data/installer_data.json
+  export INSTALLER_DATA_ALT=https://alx.sh/installer_data.json
+  export REPO_BASE=https://cdn.asahilinux.org
+  export REPORT=https://stats.asahilinux.org/report
+  export REPORT_TAG=alx-prod
 
-    #TMP="$(mktemp -d)"
-    TMP=/tmp/asahi-install
+  #TMP="$(mktemp -d)"
+  TMP=/tmp/asahi-install
 
-    echo
-    echo "Bootstrapping installer:"
+  echo
+  echo "Bootstrapping installer:"
 
-    if [ -e "$TMP" ]; then
-        mv "$TMP" "$TMP-$(date +%Y%m%d-%H%M%S)"
-    fi
+  if [ -e "$TMP" ]; then
+    mv "$TMP" "$TMP-$(date +%Y%m%d-%H%M%S)"
+  fi
 
-    mkdir -p "$TMP"
-    cd "$TMP"
+  mkdir -p "$TMP"
+  cd "$TMP"
 
-    echo "  Checking version..."
+  echo "  Checking version..."
 
-    PKG_VER="$(curl --no-progress-meter -L "$VERSION_FLAG")"
-    echo "  Version: $PKG_VER"
+  PKG_VER="$(curl --no-progress-meter -L "$VERSION_FLAG")"
+  echo "  Version: $PKG_VER"
 
-    PKG="installer-$PKG_VER.tar.gz"
+  PKG="installer-$PKG_VER.tar.gz"
 
-    echo "  Downloading..."
+  echo "  Downloading..."
 
-    curl --no-progress-meter -L -o "$PKG" "$INSTALLER_BASE/$PKG"
-    if ! curl --no-progress-meter -L -O "$INSTALLER_DATA"; then
-        echo "    Error downloading installer_data.json. GitHub might be blocked in your network."
-        echo "    Please consider using a VPN if you experience issues."
-        echo "    Trying workaround..."
-        curl --no-progress-meter -L -O "$INSTALLER_DATA_ALT"
-    fi
+  curl --no-progress-meter -L -o "$PKG" "$INSTALLER_BASE/$PKG"
+  if ! curl --no-progress-meter -L -O "$INSTALLER_DATA"; then
+    echo "    Error downloading installer_data.json. GitHub might be blocked in your network."
+    echo "    Please consider using a VPN if you experience issues."
+    echo "    Trying workaround..."
+    curl --no-progress-meter -L -O "$INSTALLER_DATA_ALT"
+  fi
 
-    echo "  Extracting..."
+  echo "  Extracting..."
 
-    tar xf "$PKG"
+  tar xf "$PKG"
 
-    echo "  Initializing..."
-    echo
+  echo "  Initializing..."
+  echo
 
-    if [ "$USER" != "root" ]; then
-        echo "The installer needs to run as root."
-        echo "Please enter your sudo password if prompted."
-        exec caffeinate -dis sudo -E ./install.sh "$@"
-    else
-        exec caffeinate -dis ./install.sh "$@"
-    fi
+  if [ "$USER" != "root" ]; then
+    echo "The installer needs to run as root."
+    echo "Please enter your sudo password if prompted."
+    exec caffeinate -dis sudo -E ./install.sh "$@"
+  else
+    exec caffeinate -dis ./install.sh "$@"
+  fi
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,62 +3,62 @@
 
 # Truncation guard
 if true; then
-    set -e
+  set -e
 
-    if [ ! -e /System ]; then
-        echo "You appear to be running this script from Linux or another non-macOS system."
-        echo "Asahi Linux can only be installed from macOS (or recoveryOS)."
-        exit 1
-    fi
+  if [ ! -e /System ]; then
+      echo "You appear to be running this script from Linux or another non-macOS system."
+      echo "Asahi Linux can only be installed from macOS (or recoveryOS)."
+      exit 1
+  fi
 
-    export LC_ALL=en_US.UTF-8
-    export LANG=en_US.UTF-8
-    export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+  export LC_ALL=en_US.UTF-8
+  export LANG=en_US.UTF-8
+  export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-    export VERSION_FLAG=http://localhost:5000/releases/latest
-    export INSTALLER_BASE=http://localhost:5000/releases
-    export INSTALLER_DATA=http://localhost:5000/data/installer_data.json
-    export REPO_BASE=https://cdn.asahilinux.org
+  export VERSION_FLAG=http://localhost:5000/releases/latest
+  export INSTALLER_BASE=http://localhost:5000/releases
+  export INSTALLER_DATA=http://localhost:5000/data/installer_data.json
+  export REPO_BASE=https://cdn.asahilinux.org
 
-    export EXPERT=1
+  export EXPERT=1
 
-    #TMP="$(mktemp -d)"
-    TMP=/tmp/asahi-install
+  #TMP="$(mktemp -d)"
+  TMP=/tmp/asahi-install
 
-    echo
-    echo "Bootstrapping installer:"
+  echo
+  echo "Bootstrapping installer:"
 
-    if [ -e "$TMP" ]; then
-        mv "$TMP" "$TMP-$(date +%Y%m%d-%H%M%S)"
-    fi
+  if [ -e "$TMP" ]; then
+    mv "$TMP" "$TMP-$(date +%Y%m%d-%H%M%S)"
+  fi
 
-    mkdir -p "$TMP"
-    cd "$TMP"
+  mkdir -p "$TMP"
+  cd "$TMP"
 
-    echo "  Checking version..."
+  echo "  Checking version..."
 
-    PKG_VER="$(curl --no-progress-meter -L "$VERSION_FLAG")"
-    echo "  Version: $PKG_VER"
+  PKG_VER="$(curl --no-progress-meter -L "$VERSION_FLAG")"
+  echo "  Version: $PKG_VER"
 
-    PKG="installer-$PKG_VER.tar.gz"
+  PKG="installer-$PKG_VER.tar.gz"
 
-    echo "  Downloading..."
+  echo "  Downloading..."
 
-    curl --no-progress-meter -L -o "$PKG" "$INSTALLER_BASE/$PKG"
-    curl --no-progress-meter -L -O "$INSTALLER_DATA"
+  curl --no-progress-meter -L -o "$PKG" "$INSTALLER_BASE/$PKG"
+  curl --no-progress-meter -L -O "$INSTALLER_DATA"
 
-    echo "  Extracting..."
+  echo "  Extracting..."
 
-    tar xf "$PKG"
+  tar xf "$PKG"
 
-    echo "  Initializing..."
-    echo
+  echo "  Initializing..."
+  echo
 
-    if [ "$USER" != "root" ]; then
-        echo "The installer needs to run as root."
-        echo "Please enter your sudo password if prompted."
-        exec caffeinate -dis sudo -E ./install.sh "$@"
-    else
-        exec caffeinate -dis ./install.sh "$@"
-    fi
+  if [ "$USER" != "root" ]; then
+    echo "The installer needs to run as root."
+    echo "Please enter your sudo password if prompted."
+    exec caffeinate -dis sudo -E ./install.sh "$@"
+  else
+    exec caffeinate -dis ./install.sh "$@"
+  fi
 fi

--- a/scripts/update-far.sh
+++ b/scripts/update-far.sh
@@ -9,30 +9,33 @@ PACKAGE_BASE="https://asahilinux-fedora.b-cdn.net/os/"
 
 curl -s https://fedora-asahi-remix.org/installer_data.json > /tmp/far.json
 
-BUILD=$(jq -r < /tmp/far.json \
-    ".os_list[].name | select(. | test(\"$VERSION\")) | sub(\".*\\\\((?<i>.*)\\\\).*\"; \"\\(.i)\")" \
-    | sort -r | head -1)
+BUILD=$(jq -r \
+  ".os_list[].name | select(. | test(\"$VERSION\")) | sub(\".*\\\\((?<i>.*)\\\\).*\"; \"\\(.i)\")" < /tmp/far.json |
+    sort -r | head -1)
 
 echo "Using build: $BUILD"
 
 jq < data/installer_data.json > /tmp/new.json --indent 4 --slurpfile far /tmp/far.json \
-    ".os_list |=
-        [
-            \$far[0].os_list[]
-            | select(.name | test(\"$VERSION.*$BUILD\"))
-            | (.name |= sub(\"$VERSION (?<i>.*) \\\\(.*\\\\)\"; \"$TARGET_VERSION \\(.i)\"))
-            | (.package |= \"$PACKAGE_BASE\" + .)
-        ] +
-        [
-            .[] | select(.name | test(\"Fedora\") == false)
-        ]
-    "
+  ".os_list |=
+    [
+      \$far[0].os_list[]
+      | select(.name | test(\"$VERSION.*$BUILD\"))
+      | (.name |= sub(\"$VERSION (?<i>.*) \\\\(.*\\\\)\"; \"$TARGET_VERSION \\(.i)\"))
+      | (.package |= \"$PACKAGE_BASE\" + .)
+    ] +
+    [
+      .[] | select(.name | test(\"Fedora\") == false)
+    ]
+  "
 
 diff -u data/installer_data.json /tmp/new.json && echo "No change" && exit 0
 
-if [ "$1" == "-u" ] ; then
-    git diff-index --quiet --cached HEAD -- || { echo "There are uncommitted changes, not updating" ; exit 1 ; }
-    mv /tmp/new.json data/installer_data.json
-    git add data/installer_data.json
-    git commit -s -m "installer_data: Update to $TARGET_VERSION $BUILD"
+if [ "$1" == "-u" ]; then
+  git diff-index --quiet --cached HEAD -- || {
+      echo "There are uncommitted changes, not updating"
+      exit 1
+  }
+  mv /tmp/new.json data/installer_data.json
+  git add data/installer_data.json
+  git commit -s -m "installer_data: Update to $TARGET_VERSION $BUILD"
 fi

--- a/src/install.sh
+++ b/src/install.sh
@@ -4,7 +4,7 @@
 set -e
 
 if [ "${0%/*}" != "$0" ]; then
-    cd "${0%/*}"
+  cd "${0%/*}"
 fi
 
 export LC_ALL=en_US.UTF-8
@@ -18,39 +18,38 @@ export SSL_CERT_FILE=$PWD/Frameworks/Python.framework/Versions/Current/etc/opens
 # so do it again for good measure.
 export PATH="$PWD/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-
 set +e
 macos_ver=$(/usr/libexec/PlistBuddy -c "Print :ProductVersion" \
-	/System/Library/CoreServices/SystemVersion.plist)
+  /System/Library/CoreServices/SystemVersion.plist)
 res=$?
 set -e
 
 if [ "$res" -ne 0 ] || [ -z "$macos_ver" ]; then
-    echo "Unable to determine macOS version. Please report a bug."
-    exit 1
+  echo "Unable to determine macOS version. Please report a bug."
+  exit 1
 fi
 
 if [ "${macos_ver%%.*}" -lt 12 ]; then
-    echo "This installer requires macOS 12.3 or later."
-    exit 1
+  echo "This installer requires macOS 12.3 or later."
+  exit 1
 fi
 
-if ! arch -arm64 ls >/dev/null 2>/dev/null; then
-    echo
-    echo "Looks like this is an Intel Mac!"
-    echo "Sorry, Asahi Linux only supports Apple Silicon machines."
-    echo "May we interest you in https://t2linux.org/ instead?"
-    exit 1
+if ! arch -arm64 ls > /dev/null 2> /dev/null; then
+  echo
+  echo "Looks like this is an Intel Mac!"
+  echo "Sorry, Asahi Linux only supports Apple Silicon machines."
+  echo "May we interest you in https://t2linux.org/ instead?"
+  exit 1
 fi
 
 if [ $(arch) != "arm64" ]; then
-    echo
-    echo "You're running the installer in Intel mode under Rosetta!"
-    echo "Don't worry, we can fix that for you. Switching to ARM64 mode..."
+  echo
+  echo "You're running the installer in Intel mode under Rosetta!"
+  echo "Don't worry, we can fix that for you. Switching to ARM64 mode..."
 
-    # This loses env vars in some security states, so just re-launch ourselves
-    exec arch -arm64 ./install.sh
+  # This loses env vars in some security states, so just re-launch ourselves
+  exec arch -arm64 ./install.sh
 fi
 
-exec </dev/tty >/dev/tty 2>/dev/tty
+exec < /dev/tty > /dev/tty 2> /dev/tty
 exec $python main.py "$@"

--- a/src/step2/step2.sh
+++ b/src/step2/step2.sh
@@ -10,7 +10,10 @@ PREBOOT="##PREBOOT##"
 self="$0"
 cd "${self%%step2.sh}"
 
-system_dir="$(cd ../../../; pwd)"
+system_dir="$(
+  cd ../../../
+  pwd
+)"
 os_name="${system_dir##*/}"
 
 # clear
@@ -25,66 +28,66 @@ echo
 BOLD="$(printf '\033[1m')"
 RST="$(printf '\033[m')"
 
-bputil -d -v "$VGID" >/tmp/bp.txt
+bputil -d -v "$VGID" > /tmp/bp.txt
 
 if ! grep -q ': Paired' /tmp/bp.txt; then
-    echo "Your system did not boot into the correct recoveryOS."
-    echo
-    echo "Each OS in your machine comes with its own copy of recoveryOS."
-    echo "In order to complete the installation, we need to boot into"
-    echo "the brand new recoveryOS that matches the OS which you are"
-    echo "installing. The final installation step cannot be completed from"
-    echo "a different recoveryOS."
-    echo
-    echo "Normally this should happen automatically after the initial"
-    echo "installer sets up your new OS as the default boot option,"
-    echo "but it seems something went wrong there. Let's try that again."
-    echo
-    echo "Press enter to continue."
-    read
+  echo "Your system did not boot into the correct recoveryOS."
+  echo
+  echo "Each OS in your machine comes with its own copy of recoveryOS."
+  echo "In order to complete the installation, we need to boot into"
+  echo "the brand new recoveryOS that matches the OS which you are"
+  echo "installing. The final installation step cannot be completed from"
+  echo "a different recoveryOS."
+  echo
+  echo "Normally this should happen automatically after the initial"
+  echo "installer sets up your new OS as the default boot option,"
+  echo "but it seems something went wrong there. Let's try that again."
+  echo
+  echo "Press enter to continue."
+  read
 
-    while ! bless --setBoot --mount "$system_dir"; do
-        echo
-        echo "bless failed. Did you mistype your password?"
-        echo "Press enter to try again."
-        read
-    done
-
+  while ! bless --setBoot --mount "$system_dir"; do
     echo
-    echo "Phew, hopefully that fixed it!"
-    echo
-    echo "Your system will now shut down. Once the screen goes blank,"
-    echo "please wait 10 seconds, then press the power button and do not"
-    echo "release it until you see the 'Entering startup options...'"
-    echo "message, then select '$os_name' again."
-    echo
-    echo "Press enter to shut down your system."
+    echo "bless failed. Did you mistype your password?"
+    echo "Press enter to try again."
     read
-    shutdown -h now
-    exit 1
+  done
+
+  echo
+  echo "Phew, hopefully that fixed it!"
+  echo
+  echo "Your system will now shut down. Once the screen goes blank,"
+  echo "please wait 10 seconds, then press the power button and do not"
+  echo "release it until you see the 'Entering startup options...'"
+  echo "message, then select '$os_name' again."
+  echo
+  echo "Press enter to shut down your system."
+  read
+  shutdown -h now
+  exit 1
 fi
 
 if ! grep -q 'one true recoveryOS' /tmp/bp.txt; then
-    echo "Your system did not boot in One True RecoveryOS (1TR) mode."
-    echo
-    echo "To finish the installation, the system must be in this special"
-    echo "mode. Perhaps you forgot to hold down the power button, or"
-    echo "momentarily released it at some point?"
-    echo
-    echo "Note that tapping and then pressing the power button again will"
-    echo "allow you to see the boot picker screen, but you will not be"
-    echo "in the correct 1TR mode. You must hold down the power button"
-    echo "in one continuous motion as you power on the machine."
-    echo
-    echo "Your system will now shut down. Once the screen goes blank,"
-    echo "please wait 10 seconds, then press the power button and do not"
-    echo "release it until you see the 'Entering startup options...'"
-    echo "message, then select '$os_name' again."
-    echo
-    echo "Press enter to shut down your system."
-    read
-    shutdown -h now
-    exit 1
+  echo "Your system did not boot in One True RecoveryOS (1TR) mode."
+  echo
+  echo "To finish the installation, the system must be in this special"
+  echo "mode. Perhaps you forgot to hold down the power button, or"
+  echo "momentarily released it at some point?"
+  echo
+  echo "Note that tapping and then pressing the power button again will"
+  echo "allow you to see the boot picker screen, but you will not be"
+  echo "in the correct 1TR mode. You must hold down the power button"
+  echo "in one continuous motion as you power on the machine."
+  echo
+  echo "Your system will now shut down. Once the screen goes blank,"
+  echo "please wait 10 seconds, then press the power button and do not"
+  echo "release it until you see the 'Entering startup options...'"
+  echo "message, then select '$os_name' again."
+  echo
+  echo "Press enter to shut down your system."
+  read
+  shutdown -h now
+  exit 1
 fi
 
 echo "You will see some messages advising you that you are changing the"
@@ -105,28 +108,28 @@ echo
 read
 
 while ! bputil -nc -v "$VGID"; do
-    echo
-    echo "bputil failed. Did you mistype your password?"
-    echo "Press enter to try again."
-    read
+  echo
+  echo "bputil failed. Did you mistype your password?"
+  echo "Press enter to try again."
+  read
 done
 
 echo
 echo
 
 if [ -e "/System/Volumes/iSCPreboot/$VGID/boot" ]; then
-    # This is an external volume, and kmutil has a problem with trying to pick
-    # up the AdminUserRecoveryInfo.plist from the wrong place. Work around that.
-    diskutil mount "$PREBOOT"
-    preboot="$(diskutil info "$PREBOOT" | grep "Mount Point" | sed 's, *Mount Point: *,,')"
-    cp -R "$preboot/$VGID/var" "/System/Volumes/iSCPreboot/$VGID/"
+  # This is an external volume, and kmutil has a problem with trying to pick
+  # up the AdminUserRecoveryInfo.plist from the wrong place. Work around that.
+  diskutil mount "$PREBOOT"
+  preboot="$(diskutil info "$PREBOOT" | grep "Mount Point" | sed 's, *Mount Point: *,,')"
+  cp -R "$preboot/$VGID/var" "/System/Volumes/iSCPreboot/$VGID/"
 fi
 
 while ! kmutil configure-boot -c boot.bin --raw --entry-point 2048 --lowest-virtual-address 0 -v "$system_dir"; do
-    echo
-    echo "kmutil failed. Did you mistype your password?"
-    echo "Press enter to try again."
-    read
+  echo
+  echo "kmutil failed. Did you mistype your password?"
+  echo "Press enter to try again."
+  read
 done
 
 echo
@@ -136,11 +139,11 @@ echo
 mount -u -w "$system_dir"
 
 if [ -e "$system_dir/.IAPhysicalMedia" ]; then
-    mv "$system_dir/.IAPhysicalMedia" "$system_dir/IAPhysicalMedia-disabled.plist"
+  mv "$system_dir/.IAPhysicalMedia" "$system_dir/IAPhysicalMedia-disabled.plist"
 fi
 
 if [ -e "$system_dir/System/Library/CoreServices/SystemVersion-disabled.plist" ]; then
-    mv -f "$system_dir/System/Library/CoreServices/SystemVersion"{-disabled,}".plist"
+  mv -f "$system_dir/System/Library/CoreServices/SystemVersion"{-disabled,}".plist"
 fi
 
 echo

--- a/test.sh
+++ b/test.sh
@@ -4,8 +4,8 @@ set -e
 cd "$(dirname "$0")"
 base="$PWD"
 
-if [ -e $HOME/.cargo/env ] ; then
-    source $HOME/.cargo/env
+if [ -e $HOME/.cargo/env ]; then
+  source $HOME/.cargo/env
 fi
 
 export INSTALLER_BASE=https://cdn.asahilinux.org/installer-dev

--- a/tools/cleanbp.sh
+++ b/tools/cleanbp.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-cat > /tmp/uuids.txt <<EOF
+cat > /tmp/uuids.txt << EOF
 3D3287DE-280D-4619-AAAB-D97469CA9C71
 C8858560-55AC-400F-BBB9-C9220A8DAC0D
 EOF
@@ -11,10 +11,10 @@ diskutil apfs listVolumeGroups >> /tmp/uuids.txt
 cd /System/Volumes/iSCPreboot
 
 for i in ????????-????-????-????-????????????; do
-    if grep -q "$i" /tmp/uuids.txt; then
-        echo "KEEP $i"
-    else
-        echo "RM $i"
-        rm -rf "$i"
-    fi
+  if grep -q "$i" /tmp/uuids.txt; then
+    echo "KEEP $i"
+  else
+    echo "RM $i"
+    rm -rf "$i"
+  fi
 done

--- a/tools/wipe-linux.sh
+++ b/tools/wipe-linux.sh
@@ -16,13 +16,13 @@ read
 read
 
 diskutil list | grep Apple_APFS | grep '\b2\.5 GB' | sed 's/.* //g' | while read i; do
-    diskutil apfs deleteContainer "$i"
+  diskutil apfs deleteContainer "$i"
 done
 diskutil list /dev/disk0 | grep -Ei 'asahi|linux|EFI' | sed 's/.* //g' | while read i; do
-    diskutil eraseVolume free free "$i"
+  diskutil eraseVolume free free "$i"
 done
 
-cat > /tmp/uuids.txt <<EOF
+cat > /tmp/uuids.txt << EOF
 3D3287DE-280D-4619-AAAB-D97469CA9C71
 C8858560-55AC-400F-BBB9-C9220A8DAC0D
 EOF
@@ -32,10 +32,10 @@ diskutil apfs listVolumeGroups >> /tmp/uuids.txt
 cd /System/Volumes/iSCPreboot
 
 for i in ????????-????-????-????-????????????; do
-    if grep -q "$i" /tmp/uuids.txt; then
-        echo "KEEP $i"
-    else
-        echo "RM $i"
-        rm -rf "$i"
-    fi
+  if grep -q "$i" /tmp/uuids.txt; then
+    echo "KEEP $i"
+  else
+    echo "RM $i"
+    rm -rf "$i"
+  fi
 done


### PR DESCRIPTION
toil: update all shell scripts to pass shfmt

partial fix for https://github.com/AsahiLinux/asahi-installer/issues/309, shellcheck changes separate

toil) undo shfmt bug until it is fixed

in a nutshell, shfmt incorrect places a space between the HEREDOC operator and its LABEL when asked to places spaces after a redirect

to see changes, ignoring whitespace ...
```
git diff -U0 -w HEAD^ HEAD 
```

which outputs:

```
diff --git a/.editorconfig b/.editorconfig
new file mode 100644
index 0000000..8111ee5
--- /dev/null
+++ b/.editorconfig
@@ -0,0 +1,4 @@
+[*.sh]
+indent_style = space
+indent_size = 2
+
diff --git a/build.sh b/build.sh
index 93530b6..be67100 100755
--- a/build.sh
+++ b/build.sh
@@ -67 +67 @@ else
-    digest=$( \
+  digest=$(
@@ -71,2 +71,3 @@ else
-        $LIBFFI_MANIFEST_URI \
-        | jq -r '[.manifests[] |
+      $LIBFFI_MANIFEST_URI |
+      jq -r '[
+          .manifests[] |
@@ -75 +76 @@ else
-            ] | first | .annotations."sh.brew.bottle.digest"' \
+        ] | first | .annotations."sh.brew.bottle.digest"'
@@ -124 +125 @@ mkdir -p "$PACKAGE/Frameworks/Python.framework"
-7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat | \
+7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat |
@@ -127 +127,0 @@ mkdir -p "$PACKAGE/Frameworks/Python.framework"
-
@@ -145 +144,0 @@ rm -f _test* _tkinter*
-
diff --git a/push.sh b/push.sh
index 85a35c5..e3b5796 100755
--- a/push.sh
+++ b/push.sh
@@ -13 +13,4 @@ case "$1" in
-    *) echo "Usage: $0 [prod|dev]" 1>&2; exit 1;;
+  *)
+     echo "Usage: $0 [prod|dev]" 1>&2
+     exit 1
+     ;;
@@ -31 +34,3 @@ put() {
-    cat /tmp/ret; echo; echo
+  cat /tmp/ret
+  echo
+  echo
diff --git a/scripts/update-far.sh b/scripts/update-far.sh
index beec9bf..e2a95dd 100755
--- a/scripts/update-far.sh
+++ b/scripts/update-far.sh
@@ -12,3 +12,3 @@ curl -s https://fedora-asahi-remix.org/installer_data.json > /tmp/far.json
-BUILD=$(jq -r < /tmp/far.json \
-    ".os_list[].name | select(. | test(\"$VERSION\")) | sub(\".*\\\\((?<i>.*)\\\\).*\"; \"\\(.i)\")" \
-    | sort -r | head -1)
+BUILD=$(jq -r \
+  ".os_list[].name | select(. | test(\"$VERSION\")) | sub(\".*\\\\((?<i>.*)\\\\).*\"; \"\\(.i)\")" </tmp/far.json  |
+    sort -r | head -1)
@@ -34 +34,4 @@ if [ "$1" == "-u" ] ; then
-    git diff-index --quiet --cached HEAD -- || { echo "There are uncommitted changes, not updating" ; exit 1 ; }
+  git diff-index --quiet --cached HEAD -- || {
+      echo "There are uncommitted changes, not updating"
+      exit 1
+  }
diff --git a/src/install.sh b/src/install.sh
index a053848..18970cd 100755
--- a/src/install.sh
+++ b/src/install.sh
@@ -21 +20,0 @@ export PATH="$PWD/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
-
diff --git a/src/step2/step2.sh b/src/step2/step2.sh
index 1932e8d..6a6c9ff 100755
--- a/src/step2/step2.sh
+++ b/src/step2/step2.sh
@@ -13 +13,4 @@ cd "${self%%step2.sh}"
-system_dir="$(cd ../../../; pwd)"
+system_dir="$(
+  cd ../../../
+  pwd
+)"
```
