### PR TITLE
asahi-firmware is a directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ fi
 echo "Copying files..."
 
 cp -r "$SRC"/* "$PACKAGE/"
-rm "$PACKAGE/asahi_firmware"
+rm -r "$PACKAGE/asahi_firmware"
 cp -r "$AFW" "$PACKAGE/"
 if [ -r "$LOGO" ]; then
     cp "$LOGO" "$PACKAGE/logo.icns"


### PR DESCRIPTION
build.sh fails for me on Linux without this change 