### PR TITLE
installer_data: Update to Fedora 41 (20241119)

### DIFF
--- a/data/installer_data.json
+++ b/data/installer_data.json
@@ -1,11 +1,11 @@
 {
     "os_list": [
         {
-            "name": "Fedora Asahi Remix 40 with KDE Plasma",
+            "name": "Fedora Asahi Remix 41 with KDE Plasma",
             "default_os_name": "Fedora Linux with KDE Plasma",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-40-kde-202410071603.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-kde-202412121600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -13,8 +13,8 @@
                 "13.5"
             ],
             "extras": [
-                "https://codecs.fedoraproject.org/openh264/40/aarch64/os/Packages/m/mozilla-openh264-2.4.1-2.fc40.aarch64.rpm",
-                "https://codecs.fedoraproject.org/openh264/40/aarch64/os/Packages/o/openh264-2.4.1-2.fc40.aarch64.rpm"
+                "https://codecs.fedoraproject.org/openh264/41/aarch64/os/Packages/m/mozilla-openh264-2.4.1-2.fc41.aarch64.rpm",
+                "https://codecs.fedoraproject.org/openh264/41/aarch64/os/Packages/o/openh264-2.4.1-2.fc41.aarch64.rpm"
             ],
             "partitions": [
                 {
@@ -22,7 +22,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0x9d773f46",
+                    "volume_id": "0xbf099044",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -36,18 +36,18 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "14510174208B",
+                    "size": "20058189824B",
                     "expand": true,
                     "image": "root.img"
                 }
             ]
         },
         {
-            "name": "Fedora Asahi Remix 40 with GNOME",
+            "name": "Fedora Asahi Remix 41 with GNOME",
             "default_os_name": "Fedora Linux with GNOME",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-40-gnome-202410071603.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-gnome-202412121600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -55,8 +55,8 @@
                 "13.5"
             ],
             "extras": [
-                "https://codecs.fedoraproject.org/openh264/40/aarch64/os/Packages/m/mozilla-openh264-2.4.1-2.fc40.aarch64.rpm",
-                "https://codecs.fedoraproject.org/openh264/40/aarch64/os/Packages/o/openh264-2.4.1-2.fc40.aarch64.rpm"
+                "https://codecs.fedoraproject.org/openh264/41/aarch64/os/Packages/m/mozilla-openh264-2.4.1-2.fc41.aarch64.rpm",
+                "https://codecs.fedoraproject.org/openh264/41/aarch64/os/Packages/o/openh264-2.4.1-2.fc41.aarch64.rpm"
             ],
             "partitions": [
                 {
@@ -64,7 +64,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0xa4805400",
+                    "volume_id": "0xc9cc3521",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -78,18 +78,18 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "11628687360B",
+                    "size": "15704502272B",
                     "expand": true,
                     "image": "root.img"
                 }
             ]
         },
         {
-            "name": "Fedora Asahi Remix 40 Server",
+            "name": "Fedora Asahi Remix 41 Server",
             "default_os_name": "Fedora Linux Server",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-40-server-202410071603.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-server-202412121600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -103,7 +103,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0x88d3c992",
+                    "volume_id": "0xa77e4028",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -117,18 +117,18 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "4575965184B",
+                    "size": "5856276480B",
                     "expand": true,
                     "image": "root.img"
                 }
             ]
         },
         {
-            "name": "Fedora Asahi Remix 40 Minimal",
+            "name": "Fedora Asahi Remix 41 Minimal",
             "default_os_name": "Fedora Linux Minimal",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
-            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-40-minimal-202410071603.zip",
+            "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-minimal-202412121600.zip",
             "icon": "fedora.icns",
             "supported_fw": [
                 "12.3",
@@ -142,7 +142,7 @@
                     "type": "EFI",
                     "size": "524288000B",
                     "format": "fat",
-                    "volume_id": "0x8293a8b7",
+                    "volume_id": "0xa18caf00",
                     "copy_firmware": true,
                     "copy_installer_data": true,
                     "source": "esp"
@@ -156,7 +156,7 @@
                 {
                     "name": "Root",
                     "type": "Linux",
-                    "size": "4053774336B",
+                    "size": "5223985152B",
                     "expand": true,
                     "image": "root.img"
                 }


### PR DESCRIPTION
Please merge initially for the dev-installer to ease testing of KDE and Gnome builds as the installer_data.json from https://fedora-asahi-remix.org/builds.html have malformed `"extras"` rpm entries.
The KDE build installed successfully after manually fixing `"extras"` on M1.

We might not want to use this exact images as the image sizes increased by ~30% compared to Fedora 40.