### PR TITLE
support Dash as /bin/sh

### DIFF
--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -15,7 +15,7 @@ if true; then
     export LANG=en_US.UTF-8
     export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-    if ! curl --no-progress-meter file:/// &>/dev/null; then
+    if ! curl --no-progress-meter file:/// >/dev/null 2>&1; then
         echo "Your version of cURL is too old. This usually means your macOS is very out"
         echo "of date. Installing Asahi Linux requires at least macOS version 13.5."
         exit 1

--- a/scripts/bootstrap-prod.sh
+++ b/scripts/bootstrap-prod.sh
@@ -15,7 +15,7 @@ if true; then
     export LANG=en_US.UTF-8
     export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-    if ! curl --no-progress-meter file:/// &>/dev/null; then
+    if ! curl --no-progress-meter file:/// >/dev/null 2>&1; then
         echo "Your version of cURL is too old. This usually means your macOS is very out"
         echo "of date. Installing Asahi Linux requires at least macOS version 13.5."
         exit 1

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,7 +15,7 @@ if true; then
     export LANG=en_US.UTF-8
     export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-    if ! curl --no-progress-meter file:/// &>/dev/null; then
+    if ! curl --no-progress-meter file:/// >/dev/null 2>&1; then
         echo "Your version of cURL is too old. This usually means your macOS is very out"
         echo "of date. Installing Asahi Linux requires at least macOS version 13.5."
         exit 1


### PR DESCRIPTION
I am using Dash for /bin/sh and the Asahi installer fails with "`Your version of cURL is too old`". This is because the curl check uses `&>/dev/null` which Dash does not support.  Updating to use the more compatible `>/dev/null 2>&1` instead.

```bash
> curl https://alx.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2289  100  2289    0     0   4364      0 --:--:-- --:--:-- --:--:--  4368
Your version of cURL is too old. This usually means your macOS is very out
of date. Installing Asahi Linux requires at least macOS version 13.5.

> sw_vers
ProductName:		macOS
ProductVersion:		15.1.1
BuildVersion:		24B91

> what /bin/sh
/bin/sh:
	PROGRAM:sh  PROJECT:dash-16
	PROGRAM:sh  PROJECT:dash-16

> /bin/sh -c 'if ! date &>&1; then echo "something wrong"; else echo "something right"; fi'
something wrong
Fri Nov 29 14:21:27 PST 2024

> /bin/sh -c 'if ! date >/dev/null 2>&1; then echo "something wrong"; else echo "something right"; fi'
something right
```