### PR TITLE
installer_data: Change `default_os_name` of all Fedora entries to just 'Fedora Linux'

### DIFF
--- a/data/installer_data.json
+++ b/data/installer_data.json
@@ -2,7 +2,7 @@
     "os_list": [
         {
             "name": "Fedora Asahi Remix 41 with KDE Plasma",
-            "default_os_name": "Fedora Linux with KDE Plasma",
+            "default_os_name": "Fedora Linux",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
             "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-kde-202412161600.zip",
@@ -44,7 +44,7 @@
         },
         {
             "name": "Fedora Asahi Remix 41 with GNOME",
-            "default_os_name": "Fedora Linux with GNOME",
+            "default_os_name": "Fedora Linux",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
             "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-gnome-202412161600.zip",
@@ -86,7 +86,7 @@
         },
         {
             "name": "Fedora Asahi Remix 41 Server",
-            "default_os_name": "Fedora Linux Server",
+            "default_os_name": "Fedora Linux",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
             "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-server-202412161600.zip",
@@ -125,7 +125,7 @@
         },
         {
             "name": "Fedora Asahi Remix 41 Minimal",
-            "default_os_name": "Fedora Linux Minimal",
+            "default_os_name": "Fedora Linux",
             "boot_object": "m1n1.bin",
             "next_object": "m1n1/boot.bin",
             "package": "https://asahilinux-fedora.b-cdn.net/os/fedora-41-minimal-202412161600.zip",


### PR DESCRIPTION
I can't understand a reason why a user would need to have the `default_os_name` variable include the selected desktop as the full name of the stub OS.  I think it would be a good idea to change `default_os_name` from "Fedora Linux Server / with {desktop environment}" to solely "Fedora Linux", for brevity's sake. I myself tend to rename the default value given in the installer to either "Fedora" or "Fedora Linux". I've also seen a good chunk of YouTubers who've uploaded install videos also change the name of the OS as well.

For example, Ubuntu Asahi sets the value to "Ubuntu", for all entries including the server entries, and the previous Arch-based alpha had the name "Asahi Linux".

Now, I know that all these instances have had to deal with only a single supported desktop environment (whereas there are now two) but I think its kind of redundant for a user to be shown this information on the boot menu by default, especially since a user would probably know which desktop they are running by the time they've booted for the first time. I think that such a change would make it less sophisticated for the end user upon entering the boot menu (not like they will have a problem distinguishing it from macOS, most users probably don't triple boot 2 Linuxes and macOS).