### PR TITLE
Avoid dividing by zero when showing progress

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -203,7 +203,7 @@ class PackageInstaller:
         st = time.time()
         self.ucache.bytes_read = 0
         while True:
-            if size is not None:
+            if size is not None and size != 0:
                 prog = copied / size * 100
                 sys.stdout.write(f"\033[3G{prog:6.2f}% ({ssize(bps)}/s)")
                 sys.stdout.flush()


### PR DESCRIPTION
PackageInstaller's fdcopy does not check if its `size` argument is zero before dividing `copied` by `size`. As a result, if non-image partitions in the installer package (typically, the ESP) contain empty files, copying those to disk raises a ZeroDivisionError that abruptly terminates the installation process, leaving it in an inconsistent state.

Check if `size` is different than zero, and if it is skip showing progress (which is totally fine and desired).