### PR TITLE
CI: add manual uefi-only boot.bin build + deploy workflows

### DIFF
--- a/.github/workflows/uefi-only-build.yaml
+++ b/.github/workflows/uefi-only-build.yaml
@@ -11,6 +11,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Allow being called from other workflows to deploy the artifact.
+  workflow_call:
 
 jobs:
   uefi-only-boot-bin:

--- a/.github/workflows/uefi-only-deploy.yaml
+++ b/.github/workflows/uefi-only-deploy.yaml
@@ -1,0 +1,44 @@
+name: uefi-only-deploy
+
+on:
+  workflow_dispatch:
+
+env:
+  UEFI_ONLY_VERSION: uefi-only-${{ vars.UEFI_DATE }}-${{ vars.UEFI_LINUX_TAG }}
+
+jobs:
+  build:
+    uses: ./.github/workflows/uefi-only-build.yaml
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: uefi-only-boot.bin
+
+      - name: Deploy to Bunny
+        env:
+          PKG_URL: https://storage.bunnycdn.com/asahilinux/os
+          PKG_VER: ${{ env.UEFI_ONLY_VERSION }}.zip
+          ACCESS_KEY: ${{ secrets.BUNNY_TOKEN }}
+        run: |
+          if [ ! -e "${PKG_VER}" ]; then
+              echo "Package not found!"
+              ls -R
+              exit 1
+          fi
+
+          upload() {
+               curl -# --fail --request PUT \
+                   --url "${2}" \
+                   --variable %ACCESS_KEY \
+                   --expand-header 'AccessKey: {{ACCESS_KEY}}' \
+                   -H "Content-Type: ${3}" \
+                   -H "Accept: application/json" \
+                   --data-binary @${1}
+          }
+
+          upload "${PKG_VER}" "${PKG_URL}/${PKG_VER}" "application/octet-stream"


### PR DESCRIPTION
Move the CI build for deployable uefi-only boot.bin artifacts to asahi-installer. Those are not tied in any way to commits in a single repository so use repository variables to determine name and used Linux and U-boot tags. Expected use is to trigger manual workflow runs after updating one or more repository variables.

This workflow deploys versioned uefi-only OS zip images for installer use. Since it depends on repository variables it will only run manually via workflow_dispatch.