### PR TITLE
firmware: Preserve ALS calibration on re-extraction

### DIFF
--- a/asahi_firmware/als.py
+++ b/asahi_firmware/als.py
@@ -3,14 +3,39 @@ import os, plistlib, subprocess, logging
 from .core import FWFile
 
 log = logging.getLogger("asahi_firmware.als")
-FACTORY_DIR = "/System/Volumes/Hardware/FactoryData/System/Library/Caches/com.apple.factorydata/"
+FACTORY_DIR = "/System/Volumes/Hardware/FactoryData/System/Library/Caches/com.apple.factorydata"
+FILENAME = "apple/aop-als-cal.bin"
 
 class AlsFWCollection(object):
-    def __init__(self):
+    def __init__(self, path=None):
         self.fwfiles = []
-        self.load()
+        if path is None:
+            self.load()
+        else:
+            self.update(path)
     def files(self):
         return self.fwfiles
+    def copy_raw(self, path):
+        try:
+            for f in os.listdir(path):
+                if not f.startswith('HmCA'):
+                    continue
+                data = open(f'{path}/{f}', 'rb').read()
+                name = f'apple/{f}'
+                fw = FWFile(name, data)
+                self.fwfiles.append((name, fw))
+        except:
+            log.warning("Unable to find raw ambient light sensor calibration data")
+            return
+    def update(self, path):
+        try:
+            data = open(f'{path}/{FILENAME}', 'rb').read()
+            fw = FWFile(FILENAME, data)
+            self.fwfiles.append((FILENAME, fw))
+        except:
+            log.warning("Unable to find ambient light sensor calibration data")
+            return
+        self.copy_raw(f'{path}/com.apple.factorydata')
     def load(self):
         ioreg = subprocess.run(["ioreg", "-r", "-a", "-n", "als", "-l"], capture_output=True)
         if ioreg.returncode != 0:
@@ -25,18 +50,7 @@ class AlsFWCollection(object):
         except:
             log.warning("Unable to find ambient light sensor calibration data")
             return
-        filename = "apple/aop-als-cal.bin"
-        fw = FWFile(filename, cal_data)
-        self.fwfiles.append((filename, fw))
-        log.info(f"  Collected {filename}")
-        try:
-            for f in os.listdir(FACTORY_DIR):
-                if not f.startswith('HmCA'):
-                    continue
-                data = open(f'{FACTORY_DIR}/{f}', 'rb').read()
-                name = f'apple/{f}'
-                fw = FWFile(name, data)
-                self.fwfiles.append((name, fw))
-        except:
-            log.warning("Unable to find raw ambient light sensor calibration data")
-            return
+        fw = FWFile(FILENAME, cal_data)
+        self.fwfiles.append((FILENAME, fw))
+        log.info(f"  Collected {FILENAME}")
+        self.copy_raw(FACTORY_DIR)

--- a/asahi_firmware/update.py
+++ b/asahi_firmware/update.py
@@ -7,6 +7,7 @@ from .bluetooth import BluetoothFWCollection
 from .multitouch import MultitouchFWCollection
 from .kernel import KernelFWCollection
 from .isp import ISPFWCollection
+from .als import AlsFWCollection
 
 def update_firmware(source, dest):
     raw_fw = source.joinpath("all_firmware.tar.gz")
@@ -29,6 +30,9 @@ def update_firmware(source, dest):
         pkg.add_files(sorted(col.files()))
 
         col = ISPFWCollection(str(tmpdir))
+        pkg.add_files(sorted(col.files()))
+
+        col = AlsFWCollection(str(tmpdir))
         pkg.add_files(sorted(col.files()))
 
     col = KernelFWCollection(str(source))

--- a/src/main.py
+++ b/src/main.py
@@ -497,6 +497,9 @@ class InstallerMain:
         base = os.path.join(mountpoint, "vendorfw")
         logging.info(f"Firmware -> {base}")
         shutil.copytree(fw_pkg.path, base, dirs_exist_ok=True)
+        asahi = os.path.join(mountpoint, "asahi")
+        all_fw = "all_firmware.tar.gz"
+        shutil.copy(all_fw, os.path.join(asahi, all_fw))
 
         print()
         p_success(f"Firmware rebuild complete. Press enter to continue.")

--- a/src/stub.py
+++ b/src/stub.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
-import os, os.path, plistlib, shutil, sys, stat, subprocess, urlcache, zipfile, logging, json
+import os, os.path, plistlib, shutil, sys, stat, subprocess, urlcache, zipfile, logging, json, tempfile
 import osenum
 from asahi_firmware.wifi import WiFiFWCollection
 from asahi_firmware.bluetooth import BluetoothFWCollection
 from asahi_firmware.multitouch import MultitouchFWCollection
 from asahi_firmware.kernel import KernelFWCollection
 from asahi_firmware.isp import ISPFWCollection
-from asahi_firmware.als import AlsFWCollection
+from asahi_firmware.als import AlsFWCollection, FACTORY_DIR
 from util import *
 
 class StubInstaller(PackageInstaller):
@@ -463,13 +463,20 @@ class StubInstaller(PackageInstaller):
         pkg.add_files(sorted(col.files()))
         logging.info("Collecting ALS firmware")
         col = AlsFWCollection()
-        pkg.add_files(sorted(col.files()))
+        als_files = sorted(col.files())
+        pkg.add_files(als_files)
         logging.info("Making fallback firmware archive")
-        subprocess.run(["tar", "czf", "all_firmware.tar.gz",
-                        "fud_firmware",
-                        "-C", "recovery/usr/share", "firmware",
-                        "-C", "../../usr/sbin", "appleh13camerad",
-                       ], check=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(f"{tmpdir}/apple")
+            for name, fwf in als_files:
+                open(f"{tmpdir}/{name}", "wb").write(fwf.data)
+            subprocess.run(["tar", "czf", "all_firmware.tar.gz",
+                            "fud_firmware",
+                            "-C", "recovery/usr/share", "firmware",
+                            "-C", "../../usr/sbin", "appleh13camerad",
+                            "-C", os.path.dirname(FACTORY_DIR), os.path.basename(FACTORY_DIR),
+                            "-C", tmpdir, "apple",
+                            ], check=True)
         self.copy_idata.append(("all_firmware.tar.gz", "all_firmware.tar.gz"))
         logging.info("Detaching recovery ramdisk")
         subprocess.run(["hdiutil", "detach", "-quiet", "recovery"])


### PR DESCRIPTION
Running asahi-fwextract does not include ALS calibration in the resulting file. So, stash it into all_firmware too, and copy it over when running fwextract