### PR TITLE
Add M3, M3 Pro and M3 Max devices using macOS 14.8.3 OTA

### DIFF
--- a/asahi_firmware/wifi.py
+++ b/asahi_firmware/wifi.py
@@ -45,9 +45,17 @@ class WiFiFWCollection(object):
                 dirnames.remove("perf")
             if "assert" in dirnames:
                 dirnames.remove("assert")
+            # remove broken firmware dir in 14.6.1 IPSW
+            if "C-4388__s-C2" in dirnames:
+                dirnames.remove("C-4388__s-C2")
             subpath = os.path.relpath(dirpath, source_path)
             for name in sorted(filenames):
                 if not any(name.endswith("." + i) for i in self.EXTMAP):
+                    continue
+                # macOS 14.6/14.8 contains {java,sumatra}_gen* files, possible
+                # for generic data. It's not clear how they are used so skip
+                # them for now
+                if "_gen" in name:
                     continue
                 path = os.path.join(dirpath, name)
                 relpath = os.path.join(subpath, name)

--- a/src/main.py
+++ b/src/main.py
@@ -45,6 +45,10 @@ CHIP_MIN_VER = {
     0x6020: "13.1",     # T6020, M2 Pro
     0x6021: "13.1",     # T6021, M2 Max
     0x6022: "13.4",     # T6022, M2 Ultra
+    0x8122: "14.8.3",   # T8122, M3
+    0x6030: "14.8.3",   # T6030, M3 Pro
+    0x6031: "14.8.3",   # T6031, M3 Max (16-core)
+    0x6034: "14.8.3",   # T6034, M3 Max (14-core)
 }
 
 DEVICES = {
@@ -71,6 +75,17 @@ DEVICES = {
     "j475cap":  Device("13.4", False),  # Mac Studio (M2 Max, 2023)
     "j475dap":  Device("13.4", False),  # Mac Studio (M2 Ultra, 2023)
     "j180dap":  Device("13.4", False),  # Mac Pro (M2 Ultra, 2023)
+    "j433ap":   Device("14.8.3", True), # iMac (24-inch, M3, 2023)
+    "j434ap":   Device("14.8.3", True), # iMac (24-inch, M3, 2023)
+    "j504ap":   Device("14.8.3", True), # MacBook Pro (14-inch, M3, 2023)
+    "j613ap":   Device("14.8.3", True), # MacBook Air (13-inch, M3, 2024)
+    "j615ap":   Device("14.8.3", True), # MacBook Air (15-inch, M3, 2024)
+    "j514sap":  Device("14.8.3", True), # MacBook Pro (14-inch, M3 Pro, 2023)
+    "j514cap":  Device("14.8.3", True), # MacBook Pro (14-inch, M3 Max, 2023)
+    "j514map":  Device("14.8.3", True), # MacBook Pro (14-inch, M3 Max, 2023)
+    "j516sap":  Device("14.8.3", True), # MacBook Pro (16-inch, M3 Pro, 2023)
+    "j516cap":  Device("14.8.3", True), # MacBook Pro (16-inch, M3 Max, 2023)
+    "j516map":  Device("14.8.3", True), # MacBook Pro (16-inch, M3 Max, 2023)
 }
 
 # Asahi Linux does not support running in a virtual machine, this option
@@ -101,6 +116,13 @@ IPSW_VERSIONS = [
          False,
          None,
          "https://updates.cdn-apple.com/2023SummerFCS/fullrestores/032-69606/D3E05CDF-E105-434C-A4A1-4E3DC7668DD0/UniversalMac_13.5_22G74_Restore.ipsw"),
+    IPSW("14.8.3",
+         "14.6",
+         "iBoot-10151.140.19",
+         "23.10.220.0.0,0",
+         True,
+         ["j433ap", "j434ap", "j504ap", "j613ap", "j615ap", "j514sap", "j514cap", "j514map", "j516sap", "j516cap", "j516map"],
+         "https://updates.cdn-apple.com/2025FallFCS/patches/089-71124/49AD260A-D47F-4B5E-A793-30446187196E/com_apple_MobileAsset_MacSoftwareUpdate/f6d1ac9149f6a06401ff87fae5b262c420bfc5f7.zip"),
 ]
 
 class InstallerMain:

--- a/src/stub.py
+++ b/src/stub.py
@@ -221,17 +221,17 @@ class StubInstaller(PackageInstaller):
 
         if self.is_ota:
             self.variant = "macOS Customer Software Update"
-            behavior = "Update"
+            self.behavior = "Update"
         else:
             self.variant = "macOS Customer"
-            behavior = "Erase"
+            self.behavior = "Erase"
 
         self.manifest = manifest
         for identity in manifest["BuildIdentities"]:
             if (identity["ApBoardID"] != f'0x{self.sysinfo.board_id:02X}' or
                 identity["ApChipID"] != f'0x{self.sysinfo.chip_id:04X}' or
                 identity["Info"]["DeviceClass"] != self.sysinfo.device_class or
-                identity["Info"]["RestoreBehavior"] != behavior or
+                identity["Info"]["RestoreBehavior"] != self.behavior or
                 identity["Info"]["Variant"] != self.variant):
                 continue
             break
@@ -413,8 +413,8 @@ class StubInstaller(PackageInstaller):
         copied = set()
         kernel_path = None
         for identity in [self.identity]:
-            if (identity["Info"]["RestoreBehavior"] != "Erase" or
-                identity["Info"]["Variant"] != "macOS Customer"):
+            if (identity["Info"]["RestoreBehavior"] != self.behavior or
+                identity["Info"]["Variant"] != self.variant):
                 continue
             device = identity["Info"]["DeviceClass"]
             if not device.endswith("ap"):


### PR DESCRIPTION
Add expert-only install support for M3 / M3 Pro / M3 Max based MacBooks
and iMacs using the 14.8.3 OTA update. 14.8.3 support iis for now
limited to these devices until drivers for HW using iboot loaded
firmware are updated for M1 and M2 based devices.
Support for M3 devices is incomplete. There is still outstanding work
in m1n1 and u-boot for basic support. Currently no operating system
images support the "14.8.3" firmware.

Includes m1n1 update to v1.6.0.

This currently only aides firmware collection and OS installation for experimenting with [tethered boot](https://asahilinux.org/docs/sw/tethered-boot/) based development. Support for `14.8.3` has to be added manually to the downloaded `installer_data.json` for the installation to succeed.