### PR TITLE
build: Use bsdtar to extract macOS python xar package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y gcc-aarch64-linux-gnu
-          sudo apt-get install --no-install-recommends -y 7zip jq
+          sudo apt-get install --no-install-recommends -y libarchive-tools 7zip jq
           rustup target install aarch64-unknown-none-softfloat
 
       - name: Build asahi-installer

--- a/build.sh
+++ b/build.sh
@@ -121,9 +121,15 @@ echo "Extracting Python framework..."
 
 mkdir -p "$PACKAGE/Frameworks/Python.framework"
 
-7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat | \
-    cpio -i -D "$PACKAGE/Frameworks/Python.framework"
-
+# test if libarchive's bsdtar is capable of extracting the payload
+# libarchive 3.7.2 (Ubuntu 24.04) is broken while 3.8.5 (Ubuntu 26.04) works
+if $(bsdtar -tf "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload > /dev/null); then
+    bsdtar -xOf "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat | \
+        cpio -i -D "$PACKAGE/Frameworks/Python.framework"
+else
+    7z x -so "$DL/$PYTHON_PKG" Python_Framework.pkg/Payload | zcat | \
+        cpio -i -D "$PACKAGE/Frameworks/Python.framework"
+fi
 
 cd "$PACKAGE/Frameworks/Python.framework/Versions/Current"
 


### PR DESCRIPTION
bsdtar is preferred over 7-Zip by some Linux distributions due to arbitrary code execution vulnarablities in 7-Zip like CVE-2026-48095. bsdtar is available in macOS with Command-line tools installed