### PR TITLE
CI: uefi-only: Use upstream dts for u-boot 2026.04 and later (take 2)

### DIFF
--- a/.github/workflows/uefi-only-build.yaml
+++ b/.github/workflows/uefi-only-build.yaml
@@ -77,8 +77,8 @@ jobs:
           mkdir -p out/esp/m1n1/
           gzip -k u-boot/u-boot-nodtb.bin
           cat m1n1/build/m1n1.bin \
-              u-boot/arch/arm/dts/t60*.dtb \
-              u-boot/arch/arm/dts/t81*.dtb \
+              u-boot/dts/upstream/src/arm64/apple/t60*.dtb \
+              u-boot/dts/upstream/src/arm64/apple/t81*.dtb \
               u-boot/u-boot-nodtb.bin.gz \
               > out/esp/m1n1/boot.bin
           cd out


### PR DESCRIPTION
Fixes failing uefi-only-build runs after updating the u-boot tag to asahi-v2026.04-2.

Fixes: 7c0f0a9 ("CI: uefi-only: Use upstream dts for u-boot 2026.04 and later")